### PR TITLE
Few changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     # We're in the root, define additional targets for developers.
     option(MY_PROJECT_BUILD_EXAMPLES   "whether or not examples should be built" ON)
     option(MY_PROJECT_BUILD_TESTS      "whether or not tests should be built" ON)
+    option(INTERPOLATION_BUILD_DOCS    "whether or not API documentation should be built" OFF)
 
     if(MY_PROJECT_BUILD_EXAMPLES)
         add_subdirectory(examples)
@@ -47,6 +48,18 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
         enable_testing()
         add_subdirectory(tests)
     endif()
+    if(INTERPOLATION_BUILD_DOCS)
+        find_package(Doxygen REQUIRED)
+        set(INTERPOLATION_DOXYGEN_CONFIG
+            ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+        configure_file(docs/Doxyfile.in
+                       ${INTERPOLATION_DOXYGEN_CONFIG}
+                       @ONLY)
+        add_custom_target(InterpolationDocs
+            COMMAND ${DOXYGEN_EXECUTABLE} ${INTERPOLATION_DOXYGEN_CONFIG}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMENT "Generating Interp API documentation"
+            VERBATIM)
+    endif()
 endif()
-
 

--- a/Interpolation/src/AkimaSpline.h
+++ b/Interpolation/src/AkimaSpline.h
@@ -5,27 +5,69 @@
 #include <Eigen/IterativeLinearSolvers>
 #include <Eigen/SparseCore>
 #include <algorithm>
-#include <iostream>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
 #include <iterator>
 #include <vector>
 
 #include "Concepts.h"
 
 namespace Interpolation {
+
+/**
+ * @brief Piecewise-cubic interpolation using locally weighted secant slopes.
+ *
+ * The object stores iterators rather than copying the samples. The referenced
+ * containers must remain alive and must not be reallocated while the
+ * interpolator is in use.
+ *
+ * @tparam xIter Random-access iterator over real abscissae.
+ * @tparam yIter Random-access iterator over real or complex ordinates.
+ * @pre The abscissa range contains at least three strictly increasing values.
+ * Queries outside the sample interval are extrapolated using the first or
+ * final cubic segment.
+ */
 template <typename xIter, typename yIter>
     requires InterpolationIteratorPair<xIter, yIter>
 class Akima {
   public:
-    // Define some class member types
+    /** @brief Scalar type used for abscissae. */
     using x_value_type = std::iter_value_t<xIter>;
+    /** @brief Scalar type used for interpolated values. */
     using y_value_type = std::iter_value_t<yIter>;
 
-    // Declare the constructor.
-    Akima(xIter, xIter, yIter);
+    /**
+     * @brief Construct an interpolator over non-owning sample ranges.
+     * @param xStart Iterator to the first abscissa.
+     * @param xFinish Iterator one past the final abscissa.
+     * @param yStart Iterator to the ordinate corresponding to `xStart`.
+     */
+    Akima(xIter xStart, xIter xFinish, yIter yStart);
 
-    // Declare the application operator.
-    y_value_type operator()(x_value_type) const;
-    y_value_type deriv(x_value_type) const;
+    /**
+     * @brief Evaluate the piecewise-cubic interpolant.
+     * @param x Query abscissa.
+     * @return Interpolated or extrapolated ordinate.
+     */
+    y_value_type operator()(x_value_type x) const;
+
+    /**
+     * @brief Evaluate the first derivative of the interpolant.
+     * @param x Query abscissa.
+     * @return First derivative at `x`.
+     */
+    y_value_type Derivative(x_value_type x) const;
+
+    /**
+     * @brief Compatibility spelling for Derivative().
+     * @param x Query abscissa.
+     * @return First derivative at `x`.
+     * @deprecated Use Derivative().
+     */
+    [[deprecated("Use Derivative()")]] y_value_type deriv(x_value_type x) const {
+        return Derivative(x);
+    }
 
   private:
     // Iterators to the function data.
@@ -36,6 +78,8 @@ class Akima {
     // m and s values
     std::vector<y_value_type> m;
     std::vector<y_value_type> s;
+
+    std::ptrdiff_t intervalIndex(x_value_type x) const;
 };
 
 template <typename xIter, typename yIter>
@@ -44,95 +88,83 @@ Akima<xIter, yIter>::Akima(xIter xS, xIter xF, yIter yS)
     : _xS{xS}, _xF{xF}, _yS{yS} {
     // Dimension of the linear system.
     const auto n = std::distance(_xS, _xF);
-    assert(n > 1);
+    assert(n > 2);
     assert(std::is_sorted(_xS, _xF));
 
     // fill out m
+    m.reserve(n - 1);
     for (int i = 0; i < n - 1; ++i) {
-        m.push_back((_yS[i + 1] - yS[i]) / (_xS[i + 1] - _xS[i]));
+        m.push_back((_yS[i + 1] - _yS[i]) / (_xS[i + 1] - _xS[i]));
     }
 
     // fill out s
-    double onehalf = static_cast<double>(1) / static_cast<double>(2);
+    using weight_type = decltype(std::abs(y_value_type{}));
+    constexpr auto oneHalf = static_cast<weight_type>(0.5);
+    s.reserve(n);
     s.push_back(m[0]);
-    s.push_back((m[0] + m[1]) * onehalf);
+    s.push_back((m[0] + m[1]) * oneHalf);
     for (int i = 2; i < n - 2; ++i) {
-        // y_value_type a = std::sqrt(std::norm(m[i + 1] - m[i]));
-        y_value_type a = std::abs(m[i + 1] - m[i]);
-
-        //     y_value_type b = std::sqrt(std::norm(m[i - 1] - m[i -
-        //     2]));
-        y_value_type b = std::abs(m[i - 1] - m[i - 2]);
-        // std::cout << m[i - 1] - m[i - 2] << "   " << b << std::endl;
-        // if (a == 0 && b != 0) {
-        //    s.push_back(m[i]);
-        // } else if (a != 0 && b == 0) {
-        //     s.push_back(m[i - 1]);
-        //	} else if (a == 0 && b == 0) {
-        //     s.push_back((m[i - 1] + m[i]) * onehalf);
-        // } else {
-        //	  s.push_back((a * m[i - 1] + b * m[i]) / (a +
-        // b));
-        //    }
-        if ((a + b) == 0) {
-            s.push_back((m[i - 1] + m[i]) / 2);
+        const auto a = std::abs(m[i + 1] - m[i]);
+        const auto b = std::abs(m[i - 1] - m[i - 2]);
+        const auto weightSum = a + b;
+        if (weightSum == weight_type{}) {
+            s.push_back((m[i - 1] + m[i]) * oneHalf);
         } else {
-            s.push_back((a * m[i - 1] + b * m[i]) / (a + b));
+            s.push_back((a * m[i - 1] + b * m[i]) / weightSum);
         }
     }
-    s.push_back((m[n - 3] + m[n - 2]) * onehalf);
+    if (n > 3) {
+        s.push_back((m[n - 3] + m[n - 2]) * oneHalf);
+    }
     s.push_back(m[n - 2]);
-    // std::cout << "Distance: " << std::distance(xS, xF) << std::endl;
+}
+
+template <typename xIter, typename yIter>
+    requires InterpolationIteratorPair<xIter, yIter>
+std::ptrdiff_t
+Akima<xIter, yIter>::intervalIndex(x_value_type x) const {
+    const auto upper = std::upper_bound(_xS, _xF, x);
+    if (upper == _xS) {
+        return 0;
+    }
+    if (upper == _xF) {
+        return std::distance(_xS, _xF) - 2;
+    }
+    return std::distance(_xS, upper) - 1;
 }
 
 template <typename xIter, typename yIter>
     requires InterpolationIteratorPair<xIter, yIter>
 Akima<xIter, yIter>::y_value_type
 Akima<xIter, yIter>::operator()(x_value_type x) const {
-    // Find the first element larger than x.
-    auto iter = std::upper_bound(_xS, _xF, x);
-    const auto n = std::distance(_xS, iter);
-    // std::cout << "n: " << n << std::endl;
-    // std::cout << "iter[-1]: " << iter[-1] << std::endl;
-    // Adjust the iterator if out of range.
-    if (iter == _xS)
-        ++iter;
-    if (iter == _xF)
-        --iter;
-    // Perform the interpolation.
-    auto a = _yS[n - 1];
-    auto b = s[n - 1];
-    auto c = (static_cast<y_value_type>(3.0) * m[n - 1] -
-              static_cast<y_value_type>(2.0) * s[n - 1] - s[n]) /
-             (iter[0] - iter[-1]);
-    auto d = (s[n - 1] + s[n] - static_cast<y_value_type>(2.0) * m[n - 1]) /
-             ((iter[0] - iter[-1]) * (iter[0] - iter[-1]));
-    return a + (x - iter[-1]) * (b + (x - iter[-1]) * (c + d * (x - iter[-1])));
+    const auto i = intervalIndex(x);
+    const auto h = _xS[i + 1] - _xS[i];
+    const auto offset = x - _xS[i];
+    const auto a = _yS[i];
+    const auto b = s[i];
+    const auto c = (static_cast<y_value_type>(3) * m[i] -
+                    static_cast<y_value_type>(2) * s[i] - s[i + 1]) /
+                   h;
+    const auto d =
+        (s[i] + s[i + 1] - static_cast<y_value_type>(2) * m[i]) / (h * h);
+    return a + offset * (b + offset * (c + d * offset));
 }
 
 template <typename xIter, typename yIter>
     requires InterpolationIteratorPair<xIter, yIter>
 Akima<xIter, yIter>::y_value_type
-Akima<xIter, yIter>::deriv(x_value_type x) const {
-    // Find the first element larger than x.
-    auto iter = std::upper_bound(_xS, _xF, x);
-    const auto n = std::distance(_xS, iter);
-    // std::cout << "n: " << n << std::endl;
-    // std::cout << "iter[-1]: " << iter[-1] << std::endl;
-    // Adjust the iterator if out of range.
-    if (iter == _xS)
-        ++iter;
-    if (iter == _xF)
-        --iter;
-    // Perform the interpolation.
-    // auto a = yS[n - 1];
-    auto b = s[n - 1];
-    auto c = (static_cast<y_value_type>(3.0) * m[n - 1] -
-              static_cast<y_value_type>(2.0) * s[n - 1] - s[n]) /
-             (iter[0] - iter[-1]);
-    auto d = (s[n - 1] + s[n] - static_cast<y_value_type>(2.0) * m[n - 1]) /
-             ((iter[0] - iter[-1]) * (iter[0] - iter[-1]));
-    return (b + (x - iter[-1]) * (2.0 * c + 3.0 * d * (x - iter[-1])));
+Akima<xIter, yIter>::Derivative(x_value_type x) const {
+    const auto i = intervalIndex(x);
+    const auto h = _xS[i + 1] - _xS[i];
+    const auto offset = x - _xS[i];
+    const auto b = s[i];
+    const auto c = (static_cast<y_value_type>(3) * m[i] -
+                    static_cast<y_value_type>(2) * s[i] - s[i + 1]) /
+                   h;
+    const auto d =
+        (s[i] + s[i + 1] - static_cast<y_value_type>(2) * m[i]) / (h * h);
+    return b + offset * (static_cast<y_value_type>(2) * c +
+                         static_cast<y_value_type>(3) * d * offset);
 }
 
 }   // namespace Interpolation

--- a/Interpolation/src/Concepts.h
+++ b/Interpolation/src/Concepts.h
@@ -6,45 +6,70 @@
 #include <iterator>
 #include <type_traits>
 
+/**
+ * @brief Interpolation algorithms and supporting mathematical utilities.
+ */
 namespace Interpolation {
 
-// Concepts for real or complex floating point types.
+/**
+ * @brief Identifies complex numbers whose component type is floating point.
+ * @tparam T Type to inspect.
+ */
 template <typename T> struct IsComplexFloatingPoint : public std::false_type {};
 
+/**
+ * @brief Specialization for `std::complex` values.
+ * @tparam T Component type of the complex value.
+ */
 template <typename T>
 struct IsComplexFloatingPoint<std::complex<T>>
     : public std::bool_constant<std::is_floating_point_v<T>> {};
 
+/** @brief A real floating-point scalar type. */
 template <typename T>
 concept RealFloatingPoint = std::floating_point<T>;
 
+/** @brief A `std::complex` type with floating-point components. */
 template <typename T>
 concept ComplexFloatingPoint =
     IsComplexFloatingPoint<std::remove_const_t<T>>::value;
 
+/** @brief A supported real or complex interpolation ordinate type. */
 template <typename T>
 concept RealOrComplexFloatingPoint =
     RealFloatingPoint<T> or ComplexFloatingPoint<T>;
 
-// Concepts for iterators with real or complex floating point values.
+/** @brief A random-access iterator over real floating-point values. */
 template <typename T>
 concept RealFloatingPointIterator = requires() {
     requires std::random_access_iterator<T>;
     requires RealFloatingPoint<std::iter_value_t<T>>;
 };
 
+/** @brief A random-access iterator over complex floating-point values. */
 template <typename T>
 concept ComplexFloatingPointIterator = requires() {
     requires std::random_access_iterator<T>;
     requires ComplexFloatingPoint<std::iter_value_t<T>>;
 };
 
+/** @brief A random-access iterator over supported real or complex values. */
 template <typename T>
 concept RealOrComplexFloatingPointIterator = requires() {
     requires std::random_access_iterator<T>;
     requires RealOrComplexFloatingPoint<std::iter_value_t<T>>;
 };
 
+/**
+ * @brief Compatible abscissa and ordinate iterators for interpolation.
+ *
+ * The abscissa iterator must contain real floating-point values. The ordinate
+ * iterator may contain real or complex floating-point values, and the two
+ * scalar types must support the arithmetic required by the interpolators.
+ *
+ * @tparam xIter Random-access iterator type for abscissae.
+ * @tparam yIter Random-access iterator type for ordinates.
+ */
 template <typename xIter, typename yIter>
 concept InterpolationIteratorPair = requires(xIter x, yIter y) {
     requires RealFloatingPointIterator<xIter>;

--- a/Interpolation/src/CubicSpline.h
+++ b/Interpolation/src/CubicSpline.h
@@ -74,20 +74,17 @@ CubicSpline<xIter, yIter>::CubicSpline(xIter xS, xIter xF, yIter yS,
     constexpr auto oneSixth =
         static_cast<x_value_type>(1) / static_cast<x_value_type>(6);
 
-    // Add in the upper diagonal.
-    if (left == CubicSplineBC::Clamped) {
-        A.insert(0, 1) = oneSixth * (_xS[1] - _xS[0]);
-    }
-    for (int i = 1; i < n - 1; ++i) {
-        A.insert(i, i + 1) = oneSixth * (_xS[i] - _xS[i - 1]);
-    }
-
-    // Add in the lower diagonal.
-    for (int i = 0; i < n - 2; ++i) {
-        A.insert(i + 1, i) = oneSixth * (_xS[i + 1] - _xS[i]);
-    }
-    if (right == CubicSplineBC::Clamped) {
-        A.insert(n - 1, n - 2) = oneSixth * (_xS[n - 1] - _xS[n - 2]);
+    // Store only the lower triangle consumed by SimplicialLDLT. A Free
+    // endpoint fixes its second derivative to zero, so the adjacent term can
+    // be eliminated from the neighbouring equation. Omitting that edge makes
+    // the full-size system symmetric without changing its solution.
+    for (int i = 0; i < n - 1; ++i) {
+        const bool adjacentToFreeLeft = i == 0 && left == CubicSplineBC::Free;
+        const bool adjacentToFreeRight =
+            i == n - 2 && right == CubicSplineBC::Free;
+        if (!adjacentToFreeLeft && !adjacentToFreeRight) {
+            A.insert(i + 1, i) = oneSixth * (_xS[i + 1] - _xS[i]);
+        }
     }
 
     // Add in the diagonal.
@@ -127,7 +124,8 @@ CubicSpline<xIter, yIter>::CubicSpline(xIter xS, xIter xF, yIter yS,
     }
 
     // Solve the linear system.
-    Eigen::SimplicialLDLT<Matrix> solver;
+    // A now stores the lower triangle of a symmetric positive-definite system.
+    Eigen::SimplicialLDLT<Matrix, Eigen::Lower> solver;
     solver.compute(A);
     _ypp = solver.solve(rhs);
     assert(solver.info() == Eigen::Success);

--- a/Interpolation/src/CubicSpline.h
+++ b/Interpolation/src/CubicSpline.h
@@ -14,33 +14,92 @@
 
 namespace Interpolation {
 
-// Enum class for boundary condition types.
-enum class CubicSplineBC { Free, Clamped };
+/** @brief Boundary-condition types supported by CubicSpline. */
+enum class CubicSplineBC {
+    /** Natural condition: the endpoint second derivative is zero. */
+    Free,
+    /** The endpoint first derivative is supplied by the caller. */
+    Clamped
+};
 
+/**
+ * @brief Piecewise-cubic spline interpolation on ordered sample points.
+ *
+ * The object stores iterators rather than copying the samples. The referenced
+ * containers must remain alive and must not be reallocated while the spline is
+ * in use. Queries outside the sample interval use the first or final cubic
+ * segment for extrapolation.
+ *
+ * @tparam xIter Random-access iterator over real abscissae.
+ * @tparam yIter Random-access iterator over real or complex ordinates.
+ * @pre The abscissa range contains at least two strictly increasing values.
+ */
 template <typename xIter, typename yIter>
     requires InterpolationIteratorPair<xIter, yIter>
 class CubicSpline {
   public:
-    // Define some class member types
+    /** @brief Scalar type used for abscissae. */
     using x_value_type = std::iter_value_t<xIter>;
+    /** @brief Scalar type used for interpolated values. */
     using y_value_type = std::iter_value_t<yIter>;
 
-    // Default constructor.
+    /**
+     * @brief Construct an unbound spline for later assignment.
+     * @warning Evaluation is invalid until a sample-backed spline is assigned.
+     */
     CubicSpline() = default;
 
-    // General constructor.
-    CubicSpline(xIter, xIter, yIter, CubicSplineBC, y_value_type, CubicSplineBC,
-                y_value_type);
+    /**
+     * @brief Construct a spline with independently selected endpoint conditions.
+     * @param xStart Iterator to the first abscissa.
+     * @param xFinish Iterator one past the final abscissa.
+     * @param yStart Iterator to the ordinate corresponding to `xStart`.
+     * @param left Left endpoint boundary-condition type.
+     * @param leftDerivative Required first derivative when `left` is Clamped;
+     *        ignored when it is Free.
+     * @param right Right endpoint boundary-condition type.
+     * @param rightDerivative Required first derivative when `right` is Clamped;
+     *        ignored when it is Free.
+     */
+    CubicSpline(xIter xStart, xIter xFinish, yIter yStart, CubicSplineBC left,
+                y_value_type leftDerivative, CubicSplineBC right,
+                y_value_type rightDerivative);
 
-    // Constructor for natural spline.
-    CubicSpline(xIter, xIter, yIter);
+    /**
+     * @brief Construct a natural spline with Free conditions at both endpoints.
+     * @param xStart Iterator to the first abscissa.
+     * @param xFinish Iterator one past the final abscissa.
+     * @param yStart Iterator to the ordinate corresponding to `xStart`.
+     */
+    CubicSpline(xIter xStart, xIter xFinish, yIter yStart);
 
-    // Constructor when boundary conditions are the same.
-    CubicSpline(xIter, xIter, yIter, CubicSplineBC, y_value_type, y_value_type);
+    /**
+     * @brief Construct a spline using one condition type at both endpoints.
+     * @param xStart Iterator to the first abscissa.
+     * @param xFinish Iterator one past the final abscissa.
+     * @param yStart Iterator to the ordinate corresponding to `xStart`.
+     * @param both Boundary-condition type for both endpoints.
+     * @param leftDerivative Left derivative when `both` is Clamped; otherwise
+     *        ignored.
+     * @param rightDerivative Right derivative when `both` is Clamped; otherwise
+     *        ignored.
+     */
+    CubicSpline(xIter xStart, xIter xFinish, yIter yStart, CubicSplineBC both,
+                y_value_type leftDerivative, y_value_type rightDerivative);
 
-    // Evaluate interpolating function.
-    y_value_type operator()(x_value_type) const;
-    y_value_type Derivative(x_value_type) const;
+    /**
+     * @brief Evaluate the spline interpolant or its endpoint-segment extrapolation.
+     * @param x Query abscissa.
+     * @return Spline value at `x`.
+     */
+    y_value_type operator()(x_value_type x) const;
+
+    /**
+     * @brief Evaluate the first derivative of the spline.
+     * @param x Query abscissa.
+     * @return First derivative at `x`.
+     */
+    y_value_type Derivative(x_value_type x) const;
 
   private:
     using Vector = Eigen::Matrix<y_value_type, Eigen::Dynamic, 1>;

--- a/Interpolation/src/Lagrange.h
+++ b/Interpolation/src/Lagrange.h
@@ -14,19 +14,42 @@
 
 namespace Interpolation {
 
+/**
+ * @brief Lagrange cardinal basis on a fixed set of nodes.
+ *
+ * The object stores an iterator to the nodes rather than copying them. The
+ * underlying container must remain alive and must not be reallocated while the
+ * basis is in use.
+ *
+ * @tparam I Random-access iterator over real floating-point nodes.
+ * @pre The range contains at least one strictly increasing node.
+ */
 template <RealFloatingPointIterator I> class LagrangePolynomial {
   public:
+    /** @brief Scalar type of the interpolation nodes. */
     using value_t = std::iter_value_t<I>;
 
-    // Constructors.
+    /** @brief Default construction is not available without a node range. */
     LagrangePolynomial() = delete;
+
+    /**
+     * @brief Construct the cardinal basis for `[start, finish)`.
+     * @param start Iterator to the first node.
+     * @param finish Iterator one past the final node.
+     */
     LagrangePolynomial(I start, I finish)
         : n{std::distance(start, finish)}, X{start} {
         assert(n > 0);
         assert(std::is_sorted(start, finish));
     }
 
-    // Evaluation of ith function at x.
+    /**
+     * @brief Evaluate one cardinal basis polynomial.
+     * @param i Zero-based basis-function index.
+     * @param x Query abscissa.
+     * @return Value of the `i`th basis polynomial at `x`.
+     * @pre `0 <= i <` the number of nodes.
+     */
     value_t operator()(int i, value_t x) const {
         auto prod1 = static_cast<value_t>(1);
         auto prod2 = static_cast<value_t>(1);
@@ -39,7 +62,13 @@ template <RealFloatingPointIterator I> class LagrangePolynomial {
         return prod1 / prod2;
     }
 
-    // Derivative function.
+    /**
+     * @brief Evaluate the derivative of one cardinal basis polynomial.
+     * @param i Zero-based basis-function index.
+     * @param x Query abscissa.
+     * @return First derivative of the `i`th basis polynomial at `x`.
+     * @pre `0 <= i <` the number of nodes.
+     */
     value_t Derivative(int i, value_t x) const {
         auto hp = static_cast<value_t>(0);
         auto prod2 = static_cast<value_t>(1);
@@ -62,22 +91,44 @@ template <RealFloatingPointIterator I> class LagrangePolynomial {
     I X;                // Iterator to the start of the nodes.
 };
 
+/**
+ * @brief Global polynomial interpolation in the Lagrange cardinal basis.
+ *
+ * The object stores iterators rather than copying its samples. Both underlying
+ * containers must remain alive and must not be reallocated while the
+ * interpolator is in use. Evaluation outside the node interval is polynomial
+ * extrapolation.
+ *
+ * @tparam xIter Random-access iterator over real abscissae.
+ * @tparam yIter Random-access iterator over real or complex ordinates.
+ * @pre The abscissa range contains at least one strictly increasing value.
+ */
 template <typename xIter, typename yIter>
     requires InterpolationIteratorPair<xIter, yIter>
 class Lagrange {
   public:
-    // Define some class member types
+    /** @brief Scalar type used for abscissae. */
     using x_value_t = std::iter_value_t<xIter>;
+    /** @brief Scalar type used for interpolated values. */
     using y_value_t = std::iter_value_t<yIter>;
 
-    // Constructors.
+    /**
+     * @brief Construct an interpolator over non-owning sample ranges.
+     * @param xS Iterator to the first abscissa.
+     * @param xF Iterator one past the final abscissa.
+     * @param yS Iterator to the ordinate corresponding to `xS`.
+     */
     Lagrange(xIter xS, xIter xF, yIter yS)
         : xS{xS}, xF{xF}, yS{yS}, h{LagrangePolynomial(xS, xF)} {}
 
-    // Return number of points
+    /** @brief Return the number of interpolation nodes. */
     auto size() const { return std::distance(xS, xF); }
 
-    // Evaluation functions
+    /**
+     * @brief Evaluate the interpolating polynomial.
+     * @param x Query abscissa.
+     * @return Interpolated or extrapolated ordinate.
+     */
     y_value_t operator()(x_value_t x) const {
         auto y = static_cast<y_value_t>(0);
         for (int i = 0; i < size(); i++) {
@@ -85,6 +136,12 @@ class Lagrange {
         }
         return y;
     }
+
+    /**
+     * @brief Evaluate the first derivative of the interpolating polynomial.
+     * @param x Query abscissa.
+     * @return First derivative at `x`.
+     */
     y_value_t Derivative(x_value_t x) const {
         auto yp = static_cast<y_value_t>(0);
         for (int i = 0; i < size(); i++) {

--- a/Interpolation/src/Linear.h
+++ b/Interpolation/src/Linear.h
@@ -11,22 +11,57 @@
 
 namespace Interpolation {
 
+/**
+ * @brief Piecewise-linear interpolation over ordered sample points.
+ *
+ * The object stores iterators rather than copying the samples. The referenced
+ * containers must therefore remain alive and must not be reallocated while the
+ * interpolator is in use. Queries outside the sample interval are extrapolated
+ * using the first or final line segment.
+ *
+ * @tparam xIter Random-access iterator over real abscissae.
+ * @tparam yIter Random-access iterator over real or complex ordinates.
+ *
+ * @pre The abscissa range contains at least two strictly increasing values.
+ */
 template <typename xIter, typename yIter>
     requires InterpolationIteratorPair<xIter, yIter>
 class Linear {
   public:
-    // Define some class member types
+    /** @brief Scalar type used for abscissae. */
     using x_value_type = std::iter_value_t<xIter>;
+    /** @brief Scalar type used for interpolated values. */
     using y_value_type = std::iter_value_t<yIter>;
 
-    // Declare the constructor.
-    Linear(xIter, xIter, yIter);
+    /**
+     * @brief Construct an interpolator over a non-owning sample range.
+     * @param xStart Iterator to the first abscissa.
+     * @param xFinish Iterator one past the final abscissa.
+     * @param yStart Iterator to the ordinate corresponding to `xStart`.
+     */
+    Linear(xIter xStart, xIter xFinish, yIter yStart);
 
-    // Declare the application operator.
-    y_value_type operator()(x_value_type) const;
+    /**
+     * @brief Evaluate the piecewise-linear interpolant or extrapolant.
+     * @param x Query abscissa.
+     * @return Interpolated ordinate.
+     * @par Complexity
+     * Logarithmic search in the number of samples.
+     */
+    y_value_type operator()(x_value_type x) const;
 
-    // Declare the derivative operator.
-    y_value_type Derivative(x_value_type) const;
+    /**
+     * @brief Evaluate the slope of the selected line segment.
+     *
+     * At an interior knot the segment to the right is selected; at the final
+     * knot the final segment is selected.
+     *
+     * @param x Query abscissa.
+     * @return Piecewise-constant first derivative.
+     * @par Complexity
+     * Logarithmic search in the number of samples.
+     */
+    y_value_type Derivative(x_value_type x) const;
 
   private:
     xIter _xS;   // Iterator to start of x values.

--- a/Interpolation/src/Polynomial.h
+++ b/Interpolation/src/Polynomial.h
@@ -5,6 +5,7 @@
 #include <initializer_list>
 #include <iostream>
 #include <iterator>
+#include <numeric>
 #include <random>
 #include <utility>
 #include <vector>
@@ -32,14 +33,11 @@ class Polynomial1D {
     /** @brief Constant coefficient iterator. */
     using const_iterator = std::vector<T>::const_iterator;
 
-    /**
-     * @brief Construct an empty sentinel polynomial.
-     * @warning Degree-dependent operations require a nonempty coefficient list.
-     */
-    Polynomial1D() = default;
+    /** @brief Construct the zero polynomial with one coefficient equal to zero. */
+    Polynomial1D() : _a{T{}} {}
 
     /** @brief Copy coefficients from a vector in ascending power order. */
-    Polynomial1D(std::vector<T> &a) : _a{a} {}
+    Polynomial1D(const std::vector<T> &a) : _a{a} {}
     /** @brief Move coefficients from a vector in ascending power order. */
     Polynomial1D(std::vector<T> &&a) : _a{std::move(a)} {}
 
@@ -125,10 +123,7 @@ class Polynomial1D {
         return Polynomial1D(a);
     }
 
-    /**
-     * @brief Return the polynomial degree.
-     * @pre The coefficient sequence is nonempty.
-     */
+    /** @brief Return the polynomial degree. */
     auto Degree() const { return _a.size() - 1; }
 
     /** @brief Evaluate the polynomial at `x` using Horner's method. */

--- a/Interpolation/src/Polynomial.h
+++ b/Interpolation/src/Polynomial.h
@@ -4,37 +4,63 @@
 #include <algorithm>
 #include <initializer_list>
 #include <iostream>
+#include <iterator>
 #include <random>
+#include <utility>
 #include <vector>
 
 #include "Concepts.h"
 
 namespace Interpolation {
 
+/**
+ * @brief One-dimensional polynomial with coefficients in ascending power order.
+ *
+ * A coefficient sequence `{a0, a1, ..., an}` represents
+ * `a0 + a1*x + ... + an*x^n`.
+ *
+ * @tparam T Real or complex floating-point coefficient type.
+ */
 template <typename T>
 requires RealOrComplexFloatingPoint<T>
 class Polynomial1D {
   public:
-    // Type alias for the scalar.
+    /** @brief Scalar type used for coefficients and evaluation. */
     using value_type = T;
+    /** @brief Mutable coefficient iterator. */
     using iterator = std::vector<T>::iterator;
+    /** @brief Constant coefficient iterator. */
     using const_iterator = std::vector<T>::const_iterator;
 
-    // Constructor default
+    /**
+     * @brief Construct an empty sentinel polynomial.
+     * @warning Degree-dependent operations require a nonempty coefficient list.
+     */
     Polynomial1D() = default;
 
-    // Construct from std::vector.
+    /** @brief Copy coefficients from a vector in ascending power order. */
     Polynomial1D(std::vector<T> &a) : _a{a} {}
+    /** @brief Move coefficients from a vector in ascending power order. */
     Polynomial1D(std::vector<T> &&a) : _a{std::move(a)} {}
 
-    // Construct from std::initializer list.
+    /** @brief Construct from coefficients in ascending power order. */
     Polynomial1D(std::initializer_list<T> list) : _a{std::vector<T>{list}} {}
 
-    // Copy and move constructors.
+    /** @brief Copy a polynomial. */
     Polynomial1D(const Polynomial1D &) = default;
+    /** @brief Move a polynomial. */
     Polynomial1D(Polynomial1D &&) = default;
 
-    // Copy constructor allowing for conversion of scalar types.
+    /** @brief Copy-assign a polynomial with the same coefficient type. */
+    Polynomial1D &operator=(const Polynomial1D &) = default;
+    /** @brief Move-assign a polynomial with the same coefficient type. */
+    Polynomial1D &operator=(Polynomial1D &&) = default;
+
+    /**
+     * @brief Copy a polynomial while converting its coefficient type.
+     * @tparam FLOAT Source coefficient type.
+     * @param rhs Source polynomial.
+     */
     template <typename FLOAT>
     requires std::is_convertible_v<FLOAT, T>
     Polynomial1D(const Polynomial1D<FLOAT> &rhs) {
@@ -42,13 +68,29 @@ class Polynomial1D {
                        [](auto x) { return static_cast<T>(x); });
     }
 
+    /**
+     * @brief Assign coefficients from a polynomial with a convertible type.
+     * @tparam FLOAT Source coefficient type.
+     * @param polinit Source polynomial.
+     * @return This polynomial.
+     */
     template <typename FLOAT>
-    requires std::is_convertible_v<FLOAT, T> Polynomial1D<T>
-    &operator=(Polynomial1D<FLOAT> &polinit) {
-        _a = polinit.polycoeff();
+        requires std::is_convertible_v<FLOAT, T> Polynomial1D<T>
+    &operator=(const Polynomial1D<FLOAT> &polinit) {
+        std::vector<T> converted;
+        converted.reserve(std::distance(polinit.cbegin(), polinit.cend()));
+        std::transform(polinit.cbegin(), polinit.cend(),
+                       std::back_inserter(converted),
+                       [](auto value) { return static_cast<T>(value); });
+        _a = std::move(converted);
         return *this;
     }
-    // Return a real random polynomial of given degree.
+
+    /**
+     * @brief Generate a real polynomial with normally distributed coefficients.
+     * @param n Requested nonnegative degree.
+     * @return Random polynomial of degree `n`.
+     */
     static Polynomial1D Random(int n)
         requires RealFloatingPoint<T>
     {
@@ -64,7 +106,11 @@ class Polynomial1D {
         return Polynomial1D(a);
     }
 
-    // Return a complex random polynomial of given degree.
+    /**
+     * @brief Generate a complex polynomial with normally distributed components.
+     * @param n Requested nonnegative degree.
+     * @return Random polynomial of degree `n`.
+     */
     static Polynomial1D Random(int n)
         requires ComplexFloatingPoint<T>
     {
@@ -79,16 +125,19 @@ class Polynomial1D {
         return Polynomial1D(a);
     }
 
-    // Returns the degree.
+    /**
+     * @brief Return the polynomial degree.
+     * @pre The coefficient sequence is nonempty.
+     */
     auto Degree() const { return _a.size() - 1; }
 
-    // Evaluates the function.
+    /** @brief Evaluate the polynomial at `x` using Horner's method. */
     T operator()(T x) const {
         return std::accumulate(_a.rbegin(), _a.rend(), static_cast<T>(0),
                                [x](auto p, auto a) { return p * x + a; });
     }
 
-    // Evaluates the derivative.
+    /** @brief Evaluate the first derivative at `x`. */
     T Derivative(T x) const {
         return std::accumulate(_a.rbegin(), std::prev(_a.rend()),
                                static_cast<T>(0),
@@ -97,27 +146,52 @@ class Polynomial1D {
                                });
     }
 
-    // Evaluates the primative.
-    T Primative(T x) const {
+    /**
+     * @brief Evaluate the zero-constant antiderivative at `x`.
+     * @return `sum(a[i] * x^(i+1) / (i+1))`.
+     */
+    T Primitive(T x) const {
         return std::accumulate(_a.rbegin(), _a.rend(), static_cast<T>(0),
                                [x, m = Degree() + 1](auto p, auto a) mutable {
                                    return p * x + a * x / static_cast<T>(m--);
                                });
     }
 
-    // Returns integral over [a,b].
-    T Integrate(T a, T b) const { return Primative(b) - Primative(a); }
+    /**
+     * @brief Compatibility spelling for Primitive().
+     * @deprecated Use Primitive().
+     */
+    [[deprecated("Use Primitive()")]] T Primative(T x) const {
+        return Primitive(x);
+    }
 
+    /** @brief Return the definite integral over `[a, b]`. */
+    T Integrate(T a, T b) const { return Primitive(b) - Primitive(a); }
+
+    /** @brief Return a mutable iterator to the first coefficient. */
     auto begin() { return _a.begin(); }
+    /** @brief Return a mutable iterator one past the final coefficient. */
     auto end() { return _a.end(); }
 
+    /** @brief Return a constant iterator to the first coefficient. */
     auto cbegin() const { return _a.cbegin(); }
+    /** @brief Return a constant iterator one past the final coefficient. */
     auto cend() const { return _a.cend(); }
 
-    // output coefficient vector
+    /**
+     * @brief Return a coefficient value.
+     * @param idx Zero-based power index.
+     * @pre `idx` is within the stored coefficient range.
+     */
     T operator[](int idx) { return _a[idx]; }
 
+    /** @brief Return a copy of the coefficient vector. */
     std::vector<T> polycoeff() const { return _a; };
+
+    /**
+     * @brief Return one coefficient, padding powers outside the range with zero.
+     * @param i Power index.
+     */
     T polycoeff(int i) const {
         if (i > this->Degree()) {
             return 0.0;
@@ -128,7 +202,7 @@ class Polynomial1D {
         }
     };
 
-    // minus operator
+    /** @brief Return the coefficient-wise additive inverse. */
     Polynomial1D<T> operator-() const {
 
         std::vector<T> myvec(this->Degree() + 1);
@@ -139,8 +213,7 @@ class Polynomial1D {
         return myret;
     };
 
-    // self operators, ie ()= operators
-    // addition
+    /** @brief Add a scalar to the constant coefficient. */
     template <typename FLOAT>
         requires std::is_convertible_v<FLOAT, T>
     Polynomial1D<T> &operator+=(FLOAT b) {
@@ -148,7 +221,7 @@ class Polynomial1D {
         return *this;
     };
 
-    // subtraction
+    /** @brief Subtract a scalar from the constant coefficient. */
     template <typename FLOAT>
         requires std::is_convertible_v<FLOAT, T>
     Polynomial1D<T> &operator-=(FLOAT b) {
@@ -156,7 +229,7 @@ class Polynomial1D {
         return *this;
     };
 
-    // multiplication
+    /** @brief Multiply every coefficient by a scalar. */
     template <typename FLOAT>
         requires std::is_convertible_v<FLOAT, T>
     Polynomial1D<T> &operator*=(FLOAT b) {
@@ -166,7 +239,7 @@ class Polynomial1D {
         return *this;
     };
 
-    // division
+    /** @brief Divide every coefficient by a nonzero scalar. */
     template <typename FLOAT>
         requires std::is_convertible_v<FLOAT, T>
     Polynomial1D<T> &operator/=(FLOAT b) {
@@ -176,7 +249,7 @@ class Polynomial1D {
         return *this;
     };
 
-    //+= operator with polynomial
+    /** @brief Add another polynomial coefficient-wise. */
     template <typename FLOAT>
         requires std::is_convertible_v<FLOAT, T>
     Polynomial1D<T> &operator+=(const Polynomial1D<FLOAT> &b) {
@@ -193,7 +266,7 @@ class Polynomial1D {
         return *this;
     };
 
-    //-= operator with polynomial
+    /** @brief Subtract another polynomial coefficient-wise. */
     template <typename FLOAT>
         requires std::is_convertible_v<FLOAT, T>
     Polynomial1D<T> &operator-=(const Polynomial1D<FLOAT> &b) {
@@ -210,7 +283,7 @@ class Polynomial1D {
         return *this;
     };
 
-    //*= operator with polynomial
+    /** @brief Multiply by another polynomial using coefficient convolution. */
     template <typename FLOAT>
         requires std::is_convertible_v<FLOAT, T>
     Polynomial1D<T> &operator*=(const Polynomial1D<FLOAT> &b) {
@@ -227,7 +300,12 @@ class Polynomial1D {
         return *this;
     };
 
-    // ostream
+    /**
+     * @brief Write coefficients in ascending power order, separated by spaces.
+     * @param os Destination stream.
+     * @param obj Polynomial to write.
+     * @return `os`.
+     */
     friend std::ostream &operator<<(std::ostream &os,
                                     const Polynomial1D<T> &obj) {
         // Write obj to stream
@@ -243,7 +321,11 @@ class Polynomial1D {
 
 }   // namespace Interpolation
 
-// non-member operators
+/**
+ * @brief Add a scalar to a polynomial's constant coefficient.
+ * @param a Polynomial operand.
+ * @param b Scalar operand.
+ */
 template <typename T, typename FLOAT>
     requires std::is_convertible_v<FLOAT, T>
 Interpolation::Polynomial1D<T>
@@ -252,6 +334,12 @@ operator+(Interpolation::Polynomial1D<T> a, FLOAT b) {
     myval += b;
     return myval;
 };
+
+/**
+ * @brief Add a scalar to a polynomial's constant coefficient.
+ * @param b Scalar operand.
+ * @param a Polynomial operand.
+ */
 template <typename T, typename FLOAT>
     requires std::is_convertible_v<FLOAT, T>
 Interpolation::Polynomial1D<T>
@@ -261,6 +349,11 @@ operator+(FLOAT b, Interpolation::Polynomial1D<T> a) {
     return myval;
 };
 
+/**
+ * @brief Subtract a scalar from a polynomial's constant coefficient.
+ * @param a Polynomial operand.
+ * @param b Scalar operand.
+ */
 template <typename T, typename FLOAT>
     requires std::is_convertible_v<FLOAT, T>
 Interpolation::Polynomial1D<T>
@@ -269,6 +362,12 @@ operator-(Interpolation::Polynomial1D<T> a, FLOAT b) {
     myval -= b;
     return myval;
 };
+
+/**
+ * @brief Subtract a polynomial from a scalar constant polynomial.
+ * @param b Scalar operand.
+ * @param a Polynomial operand.
+ */
 template <typename T, typename FLOAT>
     requires std::is_convertible_v<FLOAT, T>
 Interpolation::Polynomial1D<T>
@@ -278,6 +377,11 @@ operator-(FLOAT b, Interpolation::Polynomial1D<T> a) {
     return myval;
 };
 
+/**
+ * @brief Multiply every polynomial coefficient by a scalar.
+ * @param a Polynomial operand.
+ * @param b Scalar operand.
+ */
 template <typename T, typename FLOAT>
     requires std::is_convertible_v<FLOAT, T>
 Interpolation::Polynomial1D<T>
@@ -286,6 +390,12 @@ operator*(Interpolation::Polynomial1D<T> a, FLOAT b) {
     myval *= b;
     return myval;
 };
+
+/**
+ * @brief Multiply every polynomial coefficient by a scalar.
+ * @param b Scalar operand.
+ * @param a Polynomial operand.
+ */
 template <typename T, typename FLOAT>
     requires std::is_convertible_v<FLOAT, T>
 Interpolation::Polynomial1D<T>
@@ -295,6 +405,11 @@ operator*(FLOAT b, Interpolation::Polynomial1D<T> a) {
     return myval;
 };
 
+/**
+ * @brief Divide every polynomial coefficient by a nonzero scalar.
+ * @param a Polynomial operand.
+ * @param b Scalar operand.
+ */
 template <typename T, typename FLOAT>
     requires std::is_convertible_v<FLOAT, T>
 Interpolation::Polynomial1D<T>
@@ -304,6 +419,11 @@ operator/(Interpolation::Polynomial1D<T> a, FLOAT b) {
     return myval;
 };
 
+/**
+ * @brief Add two polynomials coefficient-wise.
+ * @param a Left polynomial operand.
+ * @param b Right polynomial operand.
+ */
 template <typename T, typename FLOAT>
     requires std::is_convertible_v<FLOAT, T>
 Interpolation::Polynomial1D<T>
@@ -318,6 +438,11 @@ operator+(const Interpolation::Polynomial1D<T> &a,
     return myval;
 };
 
+/**
+ * @brief Subtract two polynomials coefficient-wise.
+ * @param a Left polynomial operand.
+ * @param b Right polynomial operand.
+ */
 template <typename T, typename FLOAT>
     requires std::is_convertible_v<FLOAT, T>
 Interpolation::Polynomial1D<T>
@@ -332,6 +457,11 @@ operator-(const Interpolation::Polynomial1D<T> &a,
     return myval;
 };
 
+/**
+ * @brief Multiply two polynomials by coefficient convolution.
+ * @param a Left polynomial operand.
+ * @param b Right polynomial operand.
+ */
 template <typename T, typename FLOAT>
     requires std::is_convertible_v<FLOAT, T>
 Interpolation::Polynomial1D<T>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Interp
 
+C++ header-only template library for interpolation. Linear algebra is provided
+by Eigen3.
 
-c++ header-only template library for iterpolation. Linear algebra done using Eigen3. 
+## Cubic spline boundary conditions
 
+`CubicSplineBC::Free` is the natural boundary condition: the endpoint second
+derivative is zero. `CubicSplineBC::Clamped` instead specifies the endpoint
+first derivative.
+
+The spline coefficient solve uses `Eigen::SimplicialLDLT` on a symmetric
+positive-definite system stored through its lower triangle. Couplings adjacent
+to Free endpoints are eliminated because those endpoint second derivatives are
+known to be zero.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ noted below. Eigen provides the linear algebra used by cubic splines.
 | `Akima` | Local piecewise-cubic interpolation for real or complex ordinates | 3 nodes |
 | `Lagrange` | Global polynomial interpolation of sampled values | 1 node |
 | `LagrangePolynomial` | Individual Lagrange cardinal basis functions | 1 node |
-| `Polynomial1D` | Polynomial evaluation, calculus, and arithmetic | 1 coefficient |
+| `Polynomial1D` | Polynomial evaluation, calculus, and arithmetic | Defaults to zero; otherwise 1 coefficient |
 
 All interpolators store iterators rather than copying their input. Keep the
 sample containers alive and do not reallocate them while an interpolator is in

--- a/README.md
+++ b/README.md
@@ -1,15 +1,109 @@
 # Interp
 
-C++ header-only template library for interpolation. Linear algebra is provided
-by Eigen3.
+Interp is a C++20 header-only template library for one-dimensional
+interpolation and polynomial operations. Abscissae are real floating-point
+values; ordinates and polynomial coefficients may be real or complex where
+noted below. Eigen provides the linear algebra used by cubic splines.
 
-## Cubic spline boundary conditions
+## Available routines
+
+| Routine | Purpose | Minimum data |
+| --- | --- | --- |
+| `Linear` | Piecewise-linear interpolation and derivative | 2 nodes |
+| `CubicSpline` | Smooth piecewise-cubic interpolation | 2 nodes |
+| `Akima` | Local piecewise-cubic interpolation for real or complex ordinates | 3 nodes |
+| `Lagrange` | Global polynomial interpolation of sampled values | 1 node |
+| `LagrangePolynomial` | Individual Lagrange cardinal basis functions | 1 node |
+| `Polynomial1D` | Polynomial evaluation, calculus, and arithmetic | 1 coefficient |
+
+All interpolators store iterators rather than copying their input. Keep the
+sample containers alive and do not reallocate them while an interpolator is in
+use. Abscissae must be strictly increasing.
+
+## Requirements
+
+- A C++20 compiler
+- CMake 3.5 or newer
+- Git access when CMake fetches Eigen and, for tests, GoogleTest
+- Doxygen 1.9 or newer only when building the API documentation
+
+## Use from CMake
+
+Interp exports the interface target `Interpolation`. It can be brought into a
+project with `FetchContent`:
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  Interp
+  GIT_REPOSITORY https://github.com/adcm2/Interp.git
+  GIT_TAG <reviewed-commit-or-tag>
+)
+FetchContent_MakeAvailable(Interp)
+
+target_link_libraries(my_target PRIVATE Interpolation)
+```
+
+Pin a reviewed commit or release tag rather than a moving branch in consuming
+projects.
+
+## Minimal example
+
+```cpp
+#include <Interpolation/CubicSpline>
+#include <vector>
+
+std::vector<double> x{0.0, 1.0, 3.0, 4.0};
+std::vector<double> y{0.0, 1.0, 0.0, 2.0};
+
+// Three arguments select a natural spline: S'' is zero at both endpoints.
+Interpolation::CubicSpline natural{x.begin(), x.end(), y.begin()};
+double value = natural(2.0);
+double derivative = natural.Derivative(2.0);
+
+// Clamped conditions specify the endpoint first derivatives.
+Interpolation::CubicSpline clamped{
+    x.begin(), x.end(), y.begin(), Interpolation::CubicSplineBC::Clamped,
+    -0.5, 1.25};
+```
+
+Use `<Interpolation/Linear>`, `<Interpolation/AkimaSpline>`,
+`<Interpolation/Lagrange>`, or `<Interpolation/Polynomial>` to include a single
+facility, and `<Interpolation/All>` to include the complete public API.
+
+## Build, test, and document
+
+```sh
+cmake -S . -B build
+cmake --build build --parallel
+ctest --test-dir build --output-on-failure
+```
+
+Examples and tests are enabled by default for a top-level build. API
+documentation is opt-in:
+
+```sh
+cmake -S . -B build -DINTERPOLATION_BUILD_DOCS=ON
+cmake --build build --target InterpolationDocs
+```
+
+The generated API starts at `build/docs/html/index.html` and is not tracked by
+Git.
+
+## Documentation
+
+- [Getting started](docs/getting-started.md)
+- [Interpolation methods](docs/interpolation-methods.md)
+- [Development and validation](docs/development.md)
+- [Implementation status](implementation_status.md)
+
+## Cubic-spline boundary conditions
 
 `CubicSplineBC::Free` is the natural boundary condition: the endpoint second
-derivative is zero. `CubicSplineBC::Clamped` instead specifies the endpoint
-first derivative.
+derivative is zero. `CubicSplineBC::Clamped` specifies the endpoint first
+derivative.
 
-The spline coefficient solve uses `Eigen::SimplicialLDLT` on a symmetric
+The coefficient solve uses `Eigen::SimplicialLDLT` on a symmetric
 positive-definite system stored through its lower triangle. Couplings adjacent
 to Free endpoints are eliminated because those endpoint second derivatives are
 known to be zero.

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,0 +1,43 @@
+PROJECT_NAME           = "Interp"
+OUTPUT_DIRECTORY       = "@CMAKE_CURRENT_BINARY_DIR@/docs"
+CREATE_SUBDIRS         = NO
+
+INPUT                  = "@CMAKE_CURRENT_SOURCE_DIR@/Interpolation/src" \
+                         "@CMAKE_CURRENT_SOURCE_DIR@/README.md" \
+                         "@CMAKE_CURRENT_SOURCE_DIR@/implementation_status.md" \
+                         "@CMAKE_CURRENT_SOURCE_DIR@/docs"
+FILE_PATTERNS          = *.h *.md
+RECURSIVE              = YES
+EXCLUDE_PATTERNS       = */build/* */_deps/*
+EXAMPLE_PATH           = "@CMAKE_CURRENT_SOURCE_DIR@/examples"
+USE_MDFILE_AS_MAINPAGE = "@CMAKE_CURRENT_SOURCE_DIR@/README.md"
+STRIP_FROM_PATH        = "@CMAKE_CURRENT_SOURCE_DIR@"
+
+OUTPUT_LANGUAGE        = English
+MARKDOWN_SUPPORT       = YES
+AUTOLINK_SUPPORT       = YES
+JAVADOC_AUTOBRIEF      = YES
+BUILTIN_STL_SUPPORT    = YES
+CPP_CLI_SUPPORT        = NO
+
+EXTRACT_ALL            = NO
+EXTRACT_PRIVATE        = NO
+EXTRACT_PACKAGE        = NO
+EXTRACT_STATIC         = YES
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+
+QUIET                  = YES
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
+WARN_FORMAT            = "$file:$line: $text"
+
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+GENERATE_TREEVIEW      = YES
+GENERATE_LATEX         = NO
+GENERATE_XML           = NO
+GENERATE_MAN           = NO
+HAVE_DOT               = NO

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,65 @@
+# Development and validation
+
+## Clean developer build
+
+Use an out-of-source directory. In-source builds are rejected by the project.
+
+```sh
+cmake -S . -B build \
+  -DMY_PROJECT_BUILD_EXAMPLES=ON \
+  -DMY_PROJECT_BUILD_TESTS=ON
+cmake --build build --parallel
+ctest --test-dir build --output-on-failure
+```
+
+The top-level defaults enable examples and tests. When Interp is consumed with
+`add_subdirectory` or `FetchContent`, developer targets are not added.
+
+## API documentation
+
+```sh
+cmake -S . -B build -DINTERPOLATION_BUILD_DOCS=ON
+cmake --build build --target InterpolationDocs
+```
+
+Doxygen is required only when `INTERPOLATION_BUILD_DOCS` is enabled. Graphviz is
+not required. The generated entry point is `build/docs/html/index.html`.
+Doxygen warnings are treated as errors, and generated files stay in the build
+tree.
+
+## Testing conventions
+
+- Add deterministic known-answer data for every new regression.
+- Use a clearly nonuniform grid when interval indexing matters.
+- Exercise real and complex ordinates where the public concepts permit both.
+- Scale floating-point comparisons by the value magnitude and
+  `1000 * std::numeric_limits<T>::epsilon()`.
+- Keep independent reference calculations separate from production internals.
+- Do not regenerate expected numerical output merely because behavior changed;
+  explain and review every oracle change.
+
+## Validate with Eigen 3.4.0
+
+DSpecM1D consumes Eigen 3.4.0. Given an exact local Eigen source checkout and a
+local GoogleTest source checkout, configure without editing Interp's dependency
+declaration:
+
+```sh
+cmake -S . -B build-eigen-3.4 \
+  -DMY_PROJECT_BUILD_EXAMPLES=ON \
+  -DMY_PROJECT_BUILD_TESTS=ON \
+  -DINTERPOLATION_BUILD_DOCS=ON \
+  -DBUILD_TESTING=OFF \
+  -DFETCHCONTENT_SOURCE_DIR_EIGEN3=/path/to/eigen-3.4.0 \
+  -DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=/path/to/googletest
+cmake --build build-eigen-3.4 --parallel
+cmake --build build-eigen-3.4 --target InterpolationDocs
+ctest --test-dir build-eigen-3.4 --output-on-failure
+```
+
+`BUILD_TESTING=OFF` prevents Eigen's own large test registry from being added;
+Interp still enables and registers its tests through `MY_PROJECT_BUILD_TESTS`.
+
+Finish each phase with `git diff --check` and review `git status --short` to
+ensure generated files and unrelated repositories have not changed. Record the
+result in `implementation_status.md`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,83 @@
+# Getting started
+
+## Choosing an include
+
+Each public forwarding header exposes one facility:
+
+| Header | Public API |
+| --- | --- |
+| `<Interpolation/Linear>` | `Linear` |
+| `<Interpolation/CubicSpline>` | `CubicSpline`, `CubicSplineBC` |
+| `<Interpolation/AkimaSpline>` | `Akima` |
+| `<Interpolation/Lagrange>` | `Lagrange`, `LagrangePolynomial` |
+| `<Interpolation/Polynomial>` | `Polynomial1D` |
+| `<Interpolation/All>` | All of the above and the public concepts |
+
+Interp is header-only. Link the CMake interface target `Interpolation` so the
+include directory, C++ standard, Eigen dependency, and transitive requirements
+are supplied consistently.
+
+## Add Interp to a project
+
+For a sibling checkout:
+
+```cmake
+add_subdirectory(path/to/Interp)
+target_link_libraries(my_target PRIVATE Interpolation)
+```
+
+For a remote dependency, use the `FetchContent` example in the README and pin a
+reviewed immutable commit or tag.
+
+Interp currently has no standalone install/export packaging. Consumers should
+use `FetchContent` or `add_subdirectory`.
+
+## Sample ownership and input rules
+
+`Linear`, `CubicSpline`, `Akima`, `Lagrange`, and `LagrangePolynomial` retain
+random-access iterators into caller-owned data. Their source containers must:
+
+1. outlive the interpolation object;
+2. remain at the same memory location; and
+3. not be resized or otherwise reallocated.
+
+The ordinate range must contain at least as many values as the abscissa range.
+Abscissae are real and strictly increasing; duplicate nodes cause division by
+zero in the interpolation formulas.
+
+| Routine | Input precondition | Query behavior |
+| --- | --- | --- |
+| `Linear` | At least 2 nodes | Extrapolates with the first or final line segment |
+| `CubicSpline` | At least 2 nodes | Extrapolates with the first or final cubic segment |
+| `Akima` | At least 3 nodes | Extrapolates with the first or final cubic segment |
+| `Lagrange` | At least 1 node | Evaluates the global polynomial for any real query |
+| `LagrangePolynomial` | At least 1 node | Evaluates the selected basis polynomial for any real query |
+| `Polynomial1D` | At least 1 coefficient for degree operations | Evaluates for any supported scalar argument |
+
+## Scalar types
+
+Abscissae must use `float`, `double`, `long double`, or a cv-qualified form of
+one of those real types. Ordinates may use the same real types or
+`std::complex` with a floating-point component type. The abscissa and ordinate
+types must support the conversions and arithmetic required by
+`InterpolationIteratorPair`. Akima calculates its nonnegative interpolation
+weights from real magnitudes, so its cubic values and derivatives support both
+real and complex ordinates.
+
+`Polynomial1D` supports real and complex floating-point coefficient types. Its
+coefficient list is ordered from the constant term upward:
+
+```cpp
+Interpolation::Polynomial1D<double> p{1.0, -2.0, 3.0};
+// p(x) = 1 - 2x + 3x^2
+```
+
+Construction and assignment from a polynomial with a convertible coefficient
+type convert each coefficient and replace the destination coefficient list.
+
+## Boundary-condition constructors
+
+The three-argument `CubicSpline` constructor selects Free conditions at both
+ends. A six-argument overload applies one condition type to both endpoints,
+while the full seven-argument overload selects each endpoint independently.
+Derivative values passed for Free endpoints are ignored.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ zero in the interpolation formulas.
 | `Akima` | At least 3 nodes | Extrapolates with the first or final cubic segment |
 | `Lagrange` | At least 1 node | Evaluates the global polynomial for any real query |
 | `LagrangePolynomial` | At least 1 node | Evaluates the selected basis polynomial for any real query |
-| `Polynomial1D` | At least 1 coefficient for degree operations | Evaluates for any supported scalar argument |
+| `Polynomial1D` | Defaults to zero; explicit input needs at least 1 coefficient | Evaluates for any supported scalar argument |
 
 ## Scalar types
 
@@ -71,6 +71,9 @@ coefficient list is ordered from the constant term upward:
 Interpolation::Polynomial1D<double> p{1.0, -2.0, 3.0};
 // p(x) = 1 - 2x + 3x^2
 ```
+
+A default-constructed `Polynomial1D` is the degree-zero polynomial with the
+single coefficient `0`.
 
 Construction and assignment from a polynomial with a convertible coefficient
 type convert each coefficient and replace the destination coefficient list.

--- a/docs/interpolation-methods.md
+++ b/docs/interpolation-methods.md
@@ -73,10 +73,11 @@ contributes to every query, including extrapolation.
 
 ## Polynomial operations
 
-`Polynomial1D<T>` stores coefficients in ascending power order. It evaluates
-the polynomial and its derivative with Horner-style recurrences, evaluates the
-zero-constant antiderivative with `Primitive`, and computes definite integrals
-with `Integrate`.
+`Polynomial1D<T>` stores coefficients in ascending power order. Default
+construction produces the degree-zero polynomial with coefficient `0`. It
+evaluates the polynomial and its derivative with Horner-style recurrences,
+evaluates the zero-constant antiderivative with `Primitive`, and computes
+definite integrals with `Integrate`.
 
 Scalar addition and subtraction modify the constant coefficient. Scalar
 multiplication and division affect every coefficient. Polynomial addition and

--- a/docs/interpolation-methods.md
+++ b/docs/interpolation-methods.md
@@ -1,0 +1,87 @@
+# Interpolation methods
+
+## Linear interpolation
+
+On an interval `[x_i, x_{i+1}]`, `Linear` evaluates
+
+\f[
+L(x) = \frac{x_{i+1}-x}{h_i}y_i
+     + \frac{x-x_i}{h_i}y_{i+1},
+\qquad h_i=x_{i+1}-x_i.
+\f]
+
+Its derivative is the constant secant slope on the selected interval. At an
+interior knot the implementation selects the interval to the right; at the
+last knot it selects the final interval. Exterior queries use the first or
+last segment.
+
+Use linear interpolation when local monotonic behavior and low cost are more
+important than derivative continuity.
+
+## Cubic splines
+
+`CubicSpline` constructs a piecewise cubic that interpolates every knot and has
+continuous first and second derivatives. The solved unknowns are the knot
+second derivatives `M_i = S''(x_i)`.
+
+- `CubicSplineBC::Free` means `M=0` at that endpoint.
+- `CubicSplineBC::Clamped` means `S'` at that endpoint equals the supplied
+  derivative.
+
+The three-argument constructor is Free/Free, commonly called a natural spline.
+Mixed Free/Clamped combinations are supported. The implementation assembles the
+lower triangle of a symmetric positive-definite system and solves it with
+`Eigen::SimplicialLDLT<..., Eigen::Lower>`.
+
+Use a cubic spline for smooth material profiles or other data where continuous
+first and second derivatives matter. Exterior evaluation continues the first
+or final cubic piece and should not be interpreted as a physically constrained
+extrapolation model.
+
+## Akima interpolation
+
+`Akima` creates cubic Hermite pieces whose knot derivatives are weighted from
+neighboring secant slopes. It is local and can reduce oscillation around abrupt
+changes compared with a global polynomial.
+
+The implementation requires at least three nodes. At an interior knot it
+selects the interval to the right; at the final knot it selects the final
+interval. Exterior queries continue the first or final cubic piece. These
+continuations are numerical extrapolations, not physically constrained models.
+`Derivative` is the canonical derivative method; `deriv` remains as a
+deprecated compatibility alias. Real magnitude weights allow both real and
+complex ordinates.
+
+## Lagrange interpolation
+
+For distinct nodes, `LagrangePolynomial` evaluates the cardinal basis
+
+\f[
+\ell_i(x)=\prod_{j\ne i}\frac{x-x_j}{x_i-x_j}.
+\f]
+
+The basis satisfies `ell_i(x_j) = delta_ij` and its basis functions sum to one.
+`Lagrange` combines these functions with sampled ordinates:
+
+\f[
+p(x)=\sum_i y_i\ell_i(x).
+\f]
+
+With `n` nodes, the result exactly represents polynomials of degree at most
+`n-1`, apart from floating-point rounding. Evaluation is global: every sample
+contributes to every query, including extrapolation.
+
+## Polynomial operations
+
+`Polynomial1D<T>` stores coefficients in ascending power order. It evaluates
+the polynomial and its derivative with Horner-style recurrences, evaluates the
+zero-constant antiderivative with `Primitive`, and computes definite integrals
+with `Integrate`.
+
+Scalar addition and subtraction modify the constant coefficient. Scalar
+multiplication and division affect every coefficient. Polynomial addition and
+subtraction operate coefficient-wise, and polynomial multiplication uses
+coefficient convolution. The historical spelling `Primative` remains as a
+deprecated forwarding alias. Cross-type construction and assignment convert
+each coefficient when the source scalar type is convertible to the destination
+scalar type.

--- a/implementation_status.md
+++ b/implementation_status.md
@@ -1,0 +1,118 @@
+# Implementation status
+
+## Phase 1: Doxygen API surface
+
+Status: complete in the working tree; not committed or pushed.
+
+Baseline: `cubic-spline-ldlt` at
+`bdafbde8319f0147e5ac0fad67fd983dbec01743`.
+
+Completed changes:
+
+- Added the opt-in `INTERPOLATION_BUILD_DOCS` CMake option and the
+  `InterpolationDocs` target.
+- Added a warning-clean Doxygen 1.9.8 configuration that generates untracked
+  HTML in the build directory without Graphviz.
+- Documented the public concepts, interpolation classes, boundary conditions,
+  iterator lifetimes, input preconditions, evaluation domains, and polynomial
+  arithmetic API.
+- Added `Akima::Derivative` and `Polynomial1D::Primitive`; retained `deriv` and
+  `Primative` as deprecated forwarding aliases.
+
+Validation:
+
+- Default dependency build (Eigen 5.0.1 at
+  `e0f18b799e2cc7d416fdb0aec2075dceebbc8295`): all examples compiled,
+  `InterpolationDocs` completed with warnings treated as errors, and all 16
+  tests passed.
+- Exact Eigen 3.4.0 build (commit
+  `3147391d946bb4b6c68edd901f2add6ac1f31f8c`): all examples compiled,
+  `InterpolationDocs` completed with warnings treated as errors, and all 16
+  tests passed.
+- A disposable compile-and-run smoke check instantiated both new canonical
+  template methods successfully.
+- `git diff --check` passed, generated HTML remained under `/tmp`, and
+  DSpecM1D remained unchanged.
+
+The Akima limitation recorded during this phase was corrected in the combined
+defect-correction sweep below.
+
+## Phases 2 and 3: user documentation and deterministic coverage
+
+Status: complete together in the working tree; not committed or pushed.
+
+Completed documentation:
+
+- Expanded the README with the feature summary, requirements, CMake
+  integration, minimal cubic-spline example, build commands, and documentation
+  index.
+- Added getting-started, interpolation-method, and development/validation
+  guides; all pages are included in the warning-strict Doxygen build.
+
+Completed tests:
+
+- Added deterministic nonuniform known-answer coverage for Linear, Akima's
+  currently supported domain, LagrangePolynomial, Lagrange, and Polynomial1D.
+- Covered values, derivatives, extrapolation where supported, polynomial
+  calculus and arithmetic, real/complex data where the implementation
+  supports them, public concepts, forwarding headers, and both retained
+  compatibility aliases.
+- Retained the existing randomized Linear and CubicSpline tests unchanged.
+- Increased the registered Interp suite from 16 to 29 passing tests without
+  adding fixtures or numerical-oracle files.
+
+Combined validation:
+
+- Default dependency build (Eigen 5.0.1 at
+  `e0f18b799e2cc7d416fdb0aec2075dceebbc8295`): all examples compiled,
+  `InterpolationDocs` completed with warnings treated as errors, and all 29
+  tests passed.
+- Exact Eigen 3.4.0 build (commit
+  `3147391d946bb4b6c68edd901f2add6ac1f31f8c`): all examples compiled,
+  `InterpolationDocs` completed with warnings treated as errors, and all 29
+  tests passed.
+- `git diff --check` passed; the original Linear/CubicSpline test sources and
+  dependency declarations remained unchanged, no generated HTML entered the
+  repository, and DSpecM1D remained clean.
+
+## Combined defect-correction sweep
+
+Status: complete in the working tree; not committed or pushed.
+
+Completed changes:
+
+- Clamped Akima interval selection to the first or final cubic for exterior
+  queries and selected the final cubic at the final knot, removing the former
+  out-of-range indexing paths.
+- Defined Akima's minimum input as three nodes and corrected its three-node
+  slope construction so every stored slope corresponds to one knot.
+- Calculated Akima weights from real magnitudes, enabling the already-declared
+  complex-ordinate API without changing the public template interface.
+- Restored `Polynomial1D` copy and move assignment and made cross-type
+  assignment convert coefficients into a replacement destination vector.
+
+Added deterministic regressions for Akima's first/final knots, both exterior
+regions, nonlinear three-node input, two-point rejection, and real and complex
+known answers. Added compile-time and runtime checks for `Polynomial1D` copy,
+move, cross-real-type, and real-to-complex assignment.
+
+Validation:
+
+- Fresh default dependency build (Eigen 5.0.1 at
+  `e0f18b799e2cc7d416fdb0aec2075dceebbc8295`): all examples compiled, all 33
+  tests passed, and warning-strict Doxygen 1.9.8 generation succeeded.
+- Fresh exact Eigen 3.4.0 build (commit
+  `3147391d946bb4b6c68edd901f2add6ac1f31f8c`): all examples compiled, all 33
+  tests passed, and warning-strict Doxygen 1.9.8 generation succeeded.
+- All 33 tests passed with libstdc++ checked iterators enabled.
+- All 33 tests passed under AddressSanitizer and UndefinedBehaviorSanitizer
+  without findings. Leak detection was disabled because LeakSanitizer cannot
+  run under the validation environment's ptrace supervision.
+- `git diff --check` passed; existing Linear/CubicSpline tests and dependency
+  declarations remained unchanged, generated documentation stayed under
+  `/tmp`, and DSpecM1D remained unchanged.
+
+## Deferred issues
+
+- Audit default-constructed `Polynomial1D` behavior and duplicate interpolation
+  nodes separately; this sweep assigns neither issue new semantics.

--- a/implementation_status.md
+++ b/implementation_status.md
@@ -112,7 +112,34 @@ Validation:
   declarations remained unchanged, generated documentation stayed under
   `/tmp`, and DSpecM1D remained unchanged.
 
+## Pull-request review corrections
+
+Status: complete in the working tree; not committed or pushed.
+
+- Added the direct standard-library includes required for `std::accumulate` in
+  the public Polynomial header and `std::pair` in the spline tests.
+- Changed the copying coefficient-vector constructor to accept a const vector.
+- Defined default construction as a degree-zero polynomial containing the
+  single coefficient `0`, eliminating the former empty state.
+- Added deterministic tests for const-vector construction and real/complex
+  zero-polynomial degree, coefficients, evaluation, calculus, access, and
+  arithmetic.
+
+Validation:
+
+- A standalone translation unit including only the public Polynomial header
+  compiled successfully and exercised const-vector and default construction.
+- Fresh default dependency and exact Eigen 3.4.0 builds compiled all examples
+  and passed all 35 registered tests.
+- Warning-strict Doxygen 1.9.8 generation succeeded in both clean build trees.
+- All 35 tests passed with libstdc++ checked iterators enabled.
+- All 35 tests passed under AddressSanitizer and UndefinedBehaviorSanitizer
+  without findings. Leak detection was disabled because LeakSanitizer cannot
+  run under the validation environment's ptrace supervision.
+- `git diff --check` passed; dependency declarations, generated documentation,
+  and DSpecM1D remained unchanged.
+
 ## Deferred issues
 
-- Audit default-constructed `Polynomial1D` behavior and duplicate interpolation
-  nodes separately; this sweep assigns neither issue new semantics.
+- Audit duplicate interpolation nodes separately; this review phase assigns
+  that issue no new semantics.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,12 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 add_executable(Tests
-               Tests.cpp)
+               Tests.cpp
+               TestAkima.cpp
+               TestConcepts.cpp
+               TestLagrange.cpp
+               TestLinearDeterministic.cpp
+               TestPolynomial.cpp)
 target_link_libraries(Tests PRIVATE Interpolation gtest_main)
 include(GoogleTest)
 gtest_discover_tests(Tests)

--- a/tests/TestAkima.cpp
+++ b/tests/TestAkima.cpp
@@ -1,0 +1,178 @@
+#include <gtest/gtest.h>
+
+#include <Interpolation/AkimaSpline>
+#include <algorithm>
+#include <complex>
+#include <utility>
+#include <vector>
+
+#include "TestUtilities.h"
+
+namespace {
+
+template <typename x_value_t, typename y_value_t>
+std::pair<y_value_t, y_value_t> ReferenceHermite(
+    const std::vector<x_value_t> &x, const std::vector<y_value_t> &y,
+    const std::vector<y_value_t> &slopes, x_value_t query) {
+    const auto upperIterator = std::upper_bound(x.begin(), x.end(), query);
+    auto upper =
+        static_cast<std::size_t>(std::distance(x.begin(), upperIterator));
+    upper = std::clamp(upper, std::size_t{1}, x.size() - 1);
+    const auto lower = upper - 1;
+    const auto h = x[upper] - x[lower];
+    const auto secant = (y[upper] - y[lower]) / h;
+    const auto c = (static_cast<y_value_t>(3) * secant -
+                    static_cast<y_value_t>(2) * slopes[lower] -
+                    slopes[upper]) /
+                   h;
+    const auto d =
+        (slopes[lower] + slopes[upper] -
+         static_cast<y_value_t>(2) * secant) /
+        (h * h);
+    const auto offset = query - x[lower];
+    const auto value = y[lower] +
+                       offset * (slopes[lower] + offset * (c + d * offset));
+    const auto derivative = slopes[lower] +
+                            offset * (static_cast<y_value_t>(2) * c +
+                                      static_cast<y_value_t>(3) * d * offset);
+    return {value, derivative};
+}
+
+template <Interpolation::RealFloatingPoint real_t>
+void CheckComplexLinearFunction() {
+    using Complex = std::complex<real_t>;
+    const std::vector<real_t> x{-1, 0, 2, 5, 9};
+    const Complex intercept{1, 2};
+    const Complex slope{2, static_cast<real_t>(-0.5)};
+    std::vector<Complex> y;
+    for (const auto value : x) {
+        y.push_back(intercept + slope * value);
+    }
+    const Interpolation::Akima akima{x.begin(), x.end(), y.begin()};
+
+    for (const real_t query : {static_cast<real_t>(-2),
+                               static_cast<real_t>(-1),
+                               static_cast<real_t>(0.5),
+                               static_cast<real_t>(4),
+                               static_cast<real_t>(9),
+                               static_cast<real_t>(10)}) {
+        InterpolationTest::ExpectScaledNear(akima(query),
+                                            intercept + slope * query);
+        InterpolationTest::ExpectScaledNear(akima.Derivative(query), slope);
+    }
+}
+
+}   // namespace
+
+TEST(Akima, NonuniformKnownAnswerAtBoundariesAndOutsideDomain) {
+    const std::vector<double> x{0.0, 1.0, 3.0, 6.0, 10.0, 15.0};
+    const std::vector<double> y{0.0, 1.0, 0.0, 2.0, 1.0, 3.0};
+    const std::vector<double> expectedSlopes{
+        1.0, 1.0 / 4.0, 13.0 / 58.0, 17.0 / 218.0, 3.0 / 40.0,
+        2.0 / 5.0};
+    const Interpolation::Akima akima{x.begin(), x.end(), y.begin()};
+
+    for (const double query : {-2.0, 0.0, 0.5, 1.0, 2.0, 3.0, 4.5,
+                               6.0, 8.0, 10.0, 12.5, 15.0, 17.0}) {
+        const auto expected = ReferenceHermite(x, y, expectedSlopes, query);
+        SCOPED_TRACE(query);
+        InterpolationTest::ExpectScaledNear(akima(query), expected.first);
+        InterpolationTest::ExpectScaledNear(akima.Derivative(query),
+                                            expected.second);
+    }
+
+    for (std::size_t i = 0; i < x.size(); ++i) {
+        InterpolationTest::ExpectScaledNear(akima(x[i]), y[i]);
+    }
+    InterpolationTest::ExpectScaledNear(akima.Derivative(x.front()),
+                                        expectedSlopes.front());
+    InterpolationTest::ExpectScaledNear(akima.Derivative(x.back()),
+                                        expectedSlopes.back());
+}
+
+TEST(Akima, LinearFunctionIsRecovered) {
+    const std::vector<double> x{-1.0, 0.0, 2.0, 5.0, 9.0};
+    const double intercept = 1.0;
+    const double slope = 2.0;
+    std::vector<double> y;
+    for (const auto value : x) {
+        y.push_back(intercept + slope * value);
+    }
+    const Interpolation::Akima akima{x.begin(), x.end(), y.begin()};
+
+    for (const double query : {-2.0, -1.0, -0.5, 0.0, 1.0, 4.0, 8.5,
+                               9.0, 10.0}) {
+        SCOPED_TRACE(query);
+        InterpolationTest::ExpectScaledNear(akima(query),
+                                            intercept + slope * query);
+        InterpolationTest::ExpectScaledNear(akima.Derivative(query), slope);
+    }
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    InterpolationTest::ExpectScaledNear(akima.deriv(1.0), slope);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+}
+
+TEST(Akima, ComplexLinearFunctionIsRecovered) {
+    CheckComplexLinearFunction<float>();
+    CheckComplexLinearFunction<double>();
+    CheckComplexLinearFunction<long double>();
+}
+
+TEST(Akima, ComplexNonuniformKnownAnswer) {
+    using Complex = std::complex<double>;
+    const std::vector<double> x{0.0, 1.0, 3.0, 6.0, 10.0, 15.0};
+    const std::vector<double> realY{0.0, 1.0, 0.0, 2.0, 1.0, 3.0};
+    const std::vector<double> realSlopes{
+        1.0, 1.0 / 4.0, 13.0 / 58.0, 17.0 / 218.0, 3.0 / 40.0,
+        2.0 / 5.0};
+    std::vector<Complex> y;
+    std::vector<Complex> expectedSlopes;
+    for (std::size_t i = 0; i < x.size(); ++i) {
+        y.emplace_back(realY[i], 2.0 + 0.5 * x[i]);
+        expectedSlopes.emplace_back(realSlopes[i], 0.5);
+    }
+    const Interpolation::Akima akima{x.begin(), x.end(), y.begin()};
+
+    for (const double query : {-2.0, 0.0, 0.5, 2.0, 4.5, 8.0, 12.5,
+                               15.0, 17.0}) {
+        const auto expected = ReferenceHermite(x, y, expectedSlopes, query);
+        SCOPED_TRACE(query);
+        InterpolationTest::ExpectScaledNear(akima(query), expected.first);
+        InterpolationTest::ExpectScaledNear(akima.Derivative(query),
+                                            expected.second);
+    }
+}
+
+TEST(Akima, ThreeNodeNonlinearInputUsesEndpointSlopes) {
+    const std::vector<double> x{0.0, 1.0, 3.0};
+    const std::vector<double> y{0.0, 1.0, 0.0};
+    const std::vector<double> expectedSlopes{1.0, 0.25, -0.5};
+    const Interpolation::Akima akima{x.begin(), x.end(), y.begin()};
+
+    for (const double query : {-1.0, 0.0, 0.5, 1.0, 2.5, 3.0, 4.0}) {
+        const auto expected = ReferenceHermite(x, y, expectedSlopes, query);
+        SCOPED_TRACE(query);
+        InterpolationTest::ExpectScaledNear(akima(query), expected.first);
+        InterpolationTest::ExpectScaledNear(akima.Derivative(query),
+                                            expected.second);
+    }
+}
+
+#ifndef NDEBUG
+TEST(Akima, TwoPointInputIsRejected) {
+    EXPECT_DEATH(([] {
+                     const std::vector<double> x{0.0, 1.0};
+                     const std::vector<double> y{0.0, 1.0};
+                     const Interpolation::Akima akima{x.begin(), x.end(),
+                                                       y.begin()};
+                     (void)akima;
+                 }()),
+                 "");
+}
+#endif

--- a/tests/TestConcepts.cpp
+++ b/tests/TestConcepts.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+
+#include <Interpolation/AkimaSpline>
+#include <Interpolation/All>
+#include <Interpolation/CubicSpline>
+#include <Interpolation/Lagrange>
+#include <Interpolation/Linear>
+#include <Interpolation/Polynomial>
+#include <complex>
+#include <list>
+#include <vector>
+
+using RealIterator = std::vector<double>::iterator;
+using ConstRealIterator = std::vector<double>::const_iterator;
+using ComplexIterator = std::vector<std::complex<double>>::iterator;
+using IntegerIterator = std::vector<int>::iterator;
+using ListIterator = std::list<double>::iterator;
+
+static_assert(Interpolation::RealFloatingPoint<float>);
+static_assert(Interpolation::RealFloatingPoint<double>);
+static_assert(!Interpolation::RealFloatingPoint<int>);
+static_assert(Interpolation::ComplexFloatingPoint<std::complex<double>>);
+static_assert(!Interpolation::ComplexFloatingPoint<double>);
+static_assert(Interpolation::RealOrComplexFloatingPoint<long double>);
+static_assert(
+    Interpolation::RealOrComplexFloatingPoint<std::complex<long double>>);
+
+static_assert(Interpolation::RealFloatingPointIterator<RealIterator>);
+static_assert(Interpolation::RealFloatingPointIterator<ConstRealIterator>);
+static_assert(!Interpolation::RealFloatingPointIterator<ComplexIterator>);
+static_assert(!Interpolation::RealFloatingPointIterator<IntegerIterator>);
+static_assert(!Interpolation::RealFloatingPointIterator<ListIterator>);
+static_assert(Interpolation::ComplexFloatingPointIterator<ComplexIterator>);
+static_assert(
+    Interpolation::InterpolationIteratorPair<RealIterator, RealIterator>);
+static_assert(
+    Interpolation::InterpolationIteratorPair<RealIterator, ComplexIterator>);
+static_assert(
+    !Interpolation::InterpolationIteratorPair<ComplexIterator,
+                                              ComplexIterator>);
+static_assert(
+    !Interpolation::InterpolationIteratorPair<IntegerIterator, RealIterator>);
+
+TEST(ConceptsAndHeaders, PublicForwardingHeadersCompileTogether) {
+    SUCCEED();
+}

--- a/tests/TestCubicSpline.h
+++ b/tests/TestCubicSpline.h
@@ -1,12 +1,15 @@
 #ifndef INTERPOLATION_TEST_CUBIC_SPLINE_GUARD_H
 #define INTERPOLATION_TEST_CUBIC_SPLINE_GUARD_H
 
+#include <Eigen/Dense>
 #include <Interpolation/All>
+#include <algorithm>
 #include <complex>
 #include <iostream>
 #include <limits>
 #include <numbers>
 #include <random>
+#include <utility>
 #include <vector>
 
 template <Interpolation::RealFloatingPoint x_value_t,
@@ -60,5 +63,101 @@ int CubicSplineCheck() {
 
   return 0;
 }
+
+namespace CubicSplineTest {
+
+template <typename y_value_t>
+class DenseReferenceSpline {
+ public:
+  using BC = Interpolation::CubicSplineBC;
+  using Vector = Eigen::Matrix<y_value_t, Eigen::Dynamic, 1>;
+  using Matrix = Eigen::Matrix<y_value_t, Eigen::Dynamic, Eigen::Dynamic>;
+
+  DenseReferenceSpline(const std::vector<double> &x,
+                       const std::vector<y_value_t> &y, BC left,
+                       y_value_t ypl, BC right, y_value_t ypr)
+      : x_{x}, y_{y} {
+    const auto n = static_cast<Eigen::Index>(x_.size());
+    Matrix matrix = Matrix::Zero(n, n);
+    Vector rhs = Vector::Zero(n);
+
+    if (left == BC::Free) {
+      matrix(0, 0) = 1;
+    } else {
+      const auto h = x_[1] - x_[0];
+      matrix(0, 0) = h / 3.0;
+      matrix(0, 1) = h / 6.0;
+      rhs(0) = (y_[1] - y_[0]) / h - ypl;
+    }
+
+    for (Eigen::Index i = 1; i < n - 1; ++i) {
+      const auto hPrev = x_[i] - x_[i - 1];
+      const auto hNext = x_[i + 1] - x_[i];
+      matrix(i, i - 1) = hPrev / 6.0;
+      matrix(i, i) = (hPrev + hNext) / 3.0;
+      matrix(i, i + 1) = hNext / 6.0;
+      rhs(i) = (y_[i + 1] - y_[i]) / hNext -
+               (y_[i] - y_[i - 1]) / hPrev;
+    }
+
+    if (right == BC::Free) {
+      matrix(n - 1, n - 1) = 1;
+    } else {
+      const auto h = x_[n - 1] - x_[n - 2];
+      matrix(n - 1, n - 2) = h / 6.0;
+      matrix(n - 1, n - 1) = h / 3.0;
+      rhs(n - 1) = ypr - (y_[n - 1] - y_[n - 2]) / h;
+    }
+
+    second_ = matrix.fullPivLu().solve(rhs);
+  }
+
+  y_value_t operator()(double value) const {
+    const auto [lower, upper] = interval(value);
+    const auto h = x_[upper] - x_[lower];
+    const auto a = (x_[upper] - value) / h;
+    const auto b = (value - x_[lower]) / h;
+    return a * y_[lower] + b * y_[upper] +
+           ((a * a * a - a) * second_(lower) +
+            (b * b * b - b) * second_(upper)) *
+               h * h / 6.0;
+  }
+
+  y_value_t Derivative(double value) const {
+    const auto [lower, upper] = interval(value);
+    const auto h = x_[upper] - x_[lower];
+    const auto a = (x_[upper] - value) / h;
+    const auto b = (value - x_[lower]) / h;
+    return (y_[upper] - y_[lower]) / h +
+           h / 6.0 * ((-3.0 * a * a + 1.0) * second_(lower) +
+                      (3.0 * b * b - 1.0) * second_(upper));
+  }
+
+ private:
+  std::pair<Eigen::Index, Eigen::Index> interval(double value) const {
+    auto iter = std::upper_bound(x_.begin(), x_.end(), value);
+    if (iter == x_.begin()) ++iter;
+    if (iter == x_.end()) --iter;
+    const auto upper = static_cast<Eigen::Index>(std::distance(x_.begin(), iter));
+    return {upper - 1, upper};
+  }
+
+  std::vector<double> x_;
+  std::vector<y_value_t> y_;
+  Vector second_;
+};
+
+template <typename spline_t, typename y_value_t>
+std::pair<y_value_t, y_value_t> RecoverIntervalSecondDerivatives(
+    const spline_t &spline, double xLower, double xUpper,
+    const y_value_t &yLower, const y_value_t &yUpper) {
+  const auto h = xUpper - xLower;
+  const auto slope = (yUpper - yLower) / h;
+  const auto a = 6.0 * (slope - spline.Derivative(xLower)) / h;
+  const auto b = 6.0 * (spline.Derivative(xUpper) - slope) / h;
+  return {(2.0 * a - b) / 3.0, (2.0 * b - a) / 3.0};
+}
+
+}  // namespace CubicSplineTest
 
 #endif  // INTERPOLATION_TEST_CUBIC_SPLINE_GUARD_H

--- a/tests/TestLagrange.cpp
+++ b/tests/TestLagrange.cpp
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+
+#include <Interpolation/Lagrange>
+#include <complex>
+#include <vector>
+
+#include "TestUtilities.h"
+
+TEST(LagrangePolynomial, CardinalValuesPartitionAndDerivatives) {
+    const std::vector<double> nodes{-1.0, 0.5, 2.0};
+    const Interpolation::LagrangePolynomial basis{nodes.begin(), nodes.end()};
+
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            SCOPED_TRACE(i);
+            SCOPED_TRACE(j);
+            InterpolationTest::ExpectScaledNear(basis(i, nodes[j]),
+                                                i == j ? 1.0 : 0.0);
+        }
+    }
+
+    for (const double query : {-2.0, -0.25, 1.0, 3.0}) {
+        const auto expected0 = (query - 0.5) * (query - 2.0) / 4.5;
+        const auto expected1 = -(query + 1.0) * (query - 2.0) / 2.25;
+        const auto expected2 = (query + 1.0) * (query - 0.5) / 4.5;
+        const auto derivative0 = (2.0 * query - 2.5) / 4.5;
+        const auto derivative1 = -(2.0 * query - 1.0) / 2.25;
+        const auto derivative2 = (2.0 * query + 0.5) / 4.5;
+
+        SCOPED_TRACE(query);
+        InterpolationTest::ExpectScaledNear(basis(0, query), expected0);
+        InterpolationTest::ExpectScaledNear(basis(1, query), expected1);
+        InterpolationTest::ExpectScaledNear(basis(2, query), expected2);
+        InterpolationTest::ExpectScaledNear(basis.Derivative(0, query),
+                                            derivative0);
+        InterpolationTest::ExpectScaledNear(basis.Derivative(1, query),
+                                            derivative1);
+        InterpolationTest::ExpectScaledNear(basis.Derivative(2, query),
+                                            derivative2);
+        InterpolationTest::ExpectScaledNear(
+            basis(0, query) + basis(1, query) + basis(2, query), 1.0);
+        InterpolationTest::ExpectScaledNear(
+            basis.Derivative(0, query) + basis.Derivative(1, query) +
+                basis.Derivative(2, query),
+            0.0);
+    }
+}
+
+TEST(LagrangePolynomial, OneNodeBasisIsConstant) {
+    const std::vector<double> nodes{2.0};
+    const Interpolation::LagrangePolynomial basis{nodes.begin(), nodes.end()};
+
+    for (const double query : {-3.0, 2.0, 8.0}) {
+        InterpolationTest::ExpectScaledNear(basis(0, query), 1.0);
+        InterpolationTest::ExpectScaledNear(basis.Derivative(0, query), 0.0);
+    }
+}
+
+TEST(Lagrange, NonuniformRealPolynomialAndDerivativeAreRecovered) {
+    const std::vector<double> x{-1.0, 0.25, 2.0, 4.0};
+    const auto polynomial = [](double value) {
+        return 1.0 - 2.0 * value + 0.5 * value * value +
+               1.25 * value * value * value;
+    };
+    const auto derivative = [](double value) {
+        return -2.0 + value + 3.75 * value * value;
+    };
+
+    std::vector<double> y;
+    for (const auto value : x) {
+        y.push_back(polynomial(value));
+    }
+    const Interpolation::Lagrange interpolant{x.begin(), x.end(), y.begin()};
+
+    for (const double query : {-2.0, -1.0, 0.5, 2.0, 3.0, 4.0, 5.0}) {
+        SCOPED_TRACE(query);
+        InterpolationTest::ExpectScaledNear(interpolant(query),
+                                            polynomial(query));
+        InterpolationTest::ExpectScaledNear(interpolant.Derivative(query),
+                                            derivative(query));
+    }
+}
+
+TEST(Lagrange, ComplexPolynomialAndDerivativeAreRecovered) {
+    using Complex = std::complex<double>;
+    const std::vector<double> x{-1.0, 0.25, 2.0, 4.0};
+    const Complex c0{1.0, 1.0};
+    const Complex c1{-2.0, 0.5};
+    const Complex c2{0.25, -1.0};
+    const auto polynomial = [&](double value) {
+        return c0 + c1 * value + c2 * value * value;
+    };
+    const auto derivative = [&](double value) {
+        return c1 + 2.0 * c2 * value;
+    };
+
+    std::vector<Complex> y;
+    for (const auto value : x) {
+        y.push_back(polynomial(value));
+    }
+    const Interpolation::Lagrange interpolant{x.begin(), x.end(), y.begin()};
+
+    for (const double query : {-2.0, -1.0, 0.5, 3.0, 5.0}) {
+        SCOPED_TRACE(query);
+        InterpolationTest::ExpectScaledNear(interpolant(query),
+                                            polynomial(query));
+        InterpolationTest::ExpectScaledNear(interpolant.Derivative(query),
+                                            derivative(query));
+    }
+}

--- a/tests/TestLinearDeterministic.cpp
+++ b/tests/TestLinearDeterministic.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include <Interpolation/Linear>
+#include <complex>
+#include <vector>
+
+#include "TestUtilities.h"
+
+TEST(LinearDeterministic, NonuniformValuesDerivativesAndExtrapolation) {
+    const std::vector<double> x{0.0, 1.0, 3.0, 6.0};
+    const std::vector<double> y{1.0, 3.0, -1.0, 5.0};
+    const Interpolation::Linear linear{x.begin(), x.end(), y.begin()};
+
+    struct Sample {
+        double x;
+        double value;
+        double derivative;
+    };
+    const std::vector<Sample> samples{
+        {-0.5, 0.0, 2.0}, {0.0, 1.0, 2.0}, {0.5, 2.0, 2.0},
+        {1.0, 3.0, -2.0}, {2.0, 1.0, -2.0}, {3.0, -1.0, 2.0},
+        {4.5, 2.0, 2.0}, {6.0, 5.0, 2.0}, {7.0, 7.0, 2.0}};
+
+    for (const auto &sample : samples) {
+        SCOPED_TRACE(sample.x);
+        InterpolationTest::ExpectScaledNear(linear(sample.x), sample.value);
+        InterpolationTest::ExpectScaledNear(linear.Derivative(sample.x),
+                                            sample.derivative);
+    }
+}
+
+TEST(LinearDeterministic, ComplexLinearFunctionIsRecovered) {
+    using Complex = std::complex<double>;
+    const std::vector<double> x{-1.0, 0.5, 2.0, 5.0};
+    const Complex intercept{1.0, 2.0};
+    const Complex slope{2.0, -0.5};
+    std::vector<Complex> y;
+    for (const auto value : x) {
+        y.push_back(intercept + slope * value);
+    }
+
+    const Interpolation::Linear linear{x.begin(), x.end(), y.begin()};
+    for (const double query : {-2.0, -1.0, 0.0, 1.25, 5.0, 6.0}) {
+        SCOPED_TRACE(query);
+        InterpolationTest::ExpectScaledNear(linear(query),
+                                            intercept + slope * query);
+        InterpolationTest::ExpectScaledNear(linear.Derivative(query), slope);
+    }
+}

--- a/tests/TestPolynomial.cpp
+++ b/tests/TestPolynomial.cpp
@@ -25,6 +25,38 @@ void ExpectCoefficients(
 
 }   // namespace
 
+TEST(Polynomial1D, DefaultConstructionIsZeroPolynomial) {
+    Interpolation::Polynomial1D<double> zero;
+
+    EXPECT_EQ(zero.Degree(), 0);
+    ExpectCoefficients(zero, std::vector<double>{0.0});
+    InterpolationTest::ExpectScaledNear(zero(2.0), 0.0);
+    InterpolationTest::ExpectScaledNear(zero.Derivative(2.0), 0.0);
+    InterpolationTest::ExpectScaledNear(zero.Primitive(2.0), 0.0);
+    InterpolationTest::ExpectScaledNear(zero.Integrate(-1.0, 2.0), 0.0);
+    InterpolationTest::ExpectScaledNear(zero[0], 0.0);
+    InterpolationTest::ExpectScaledNear(zero.polycoeff(-1), 0.0);
+    InterpolationTest::ExpectScaledNear(zero.polycoeff(1), 0.0);
+
+    const Interpolation::Polynomial1D<double> polynomial{1.0, -2.0, 3.0};
+    ExpectCoefficients(zero + polynomial,
+                       std::vector<double>{1.0, -2.0, 3.0});
+    ExpectCoefficients(zero * polynomial,
+                       std::vector<double>{0.0, 0.0, 0.0});
+    ExpectCoefficients(zero + 2.0, std::vector<double>{2.0});
+
+    const Interpolation::Polynomial1D<std::complex<double>> complexZero;
+    ExpectCoefficients(complexZero,
+                       std::vector<std::complex<double>>{{0.0, 0.0}});
+}
+
+TEST(Polynomial1D, ConstructsFromConstCoefficientVector) {
+    const std::vector<double> coefficients{1.0, -2.0, 3.0};
+    const Interpolation::Polynomial1D<double> polynomial{coefficients};
+
+    ExpectCoefficients(polynomial, coefficients);
+}
+
 TEST(Polynomial1D, EvaluationCalculusAndCoefficientAccess) {
     Interpolation::Polynomial1D<double> polynomial{1.0, -2.0, 3.0};
 

--- a/tests/TestPolynomial.cpp
+++ b/tests/TestPolynomial.cpp
@@ -1,0 +1,154 @@
+#include <gtest/gtest.h>
+
+#include <Interpolation/Polynomial>
+#include <complex>
+#include <sstream>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "TestUtilities.h"
+
+namespace {
+
+template <typename value_t>
+void ExpectCoefficients(
+    const Interpolation::Polynomial1D<value_t> &polynomial,
+    const std::vector<value_t> &expected) {
+    ASSERT_EQ(polynomial.polycoeff().size(), expected.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        SCOPED_TRACE(i);
+        InterpolationTest::ExpectScaledNear(polynomial.polycoeff(i),
+                                            expected[i]);
+    }
+}
+
+}   // namespace
+
+TEST(Polynomial1D, EvaluationCalculusAndCoefficientAccess) {
+    Interpolation::Polynomial1D<double> polynomial{1.0, -2.0, 3.0};
+
+    EXPECT_EQ(polynomial.Degree(), 2);
+    InterpolationTest::ExpectScaledNear(polynomial(2.0), 9.0);
+    InterpolationTest::ExpectScaledNear(polynomial.Derivative(2.0), 10.0);
+    InterpolationTest::ExpectScaledNear(polynomial.Primitive(2.0), 6.0);
+    InterpolationTest::ExpectScaledNear(polynomial.Integrate(-1.0, 2.0), 9.0);
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    InterpolationTest::ExpectScaledNear(polynomial.Primative(2.0), 6.0);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+    InterpolationTest::ExpectScaledNear(polynomial[1], -2.0);
+    InterpolationTest::ExpectScaledNear(polynomial.polycoeff(-1), 0.0);
+    InterpolationTest::ExpectScaledNear(polynomial.polycoeff(3), 0.0);
+    ExpectCoefficients(polynomial, std::vector<double>{1.0, -2.0, 3.0});
+
+    *polynomial.begin() = 4.0;
+    InterpolationTest::ExpectScaledNear(polynomial(0.0), 4.0);
+    EXPECT_EQ(std::distance(polynomial.cbegin(), polynomial.cend()), 3);
+}
+
+TEST(Polynomial1D, ScalarAndPolynomialArithmetic) {
+    const Interpolation::Polynomial1D<double> polynomial{1.0, -2.0, 3.0};
+    const Interpolation::Polynomial1D<double> other{-1.0, 4.0};
+
+    ExpectCoefficients(polynomial + 2.0,
+                       std::vector<double>{3.0, -2.0, 3.0});
+    ExpectCoefficients(2.0 + polynomial,
+                       std::vector<double>{3.0, -2.0, 3.0});
+    ExpectCoefficients(polynomial - 2.0,
+                       std::vector<double>{-1.0, -2.0, 3.0});
+    ExpectCoefficients(2.0 - polynomial,
+                       std::vector<double>{1.0, 2.0, -3.0});
+    ExpectCoefficients(polynomial * 2.0,
+                       std::vector<double>{2.0, -4.0, 6.0});
+    ExpectCoefficients(2.0 * polynomial,
+                       std::vector<double>{2.0, -4.0, 6.0});
+    ExpectCoefficients(polynomial / 2.0,
+                       std::vector<double>{0.5, -1.0, 1.5});
+
+    ExpectCoefficients(polynomial + other,
+                       std::vector<double>{0.0, 2.0, 3.0});
+    ExpectCoefficients(polynomial - other,
+                       std::vector<double>{2.0, -6.0, 3.0});
+    ExpectCoefficients(polynomial * other,
+                       std::vector<double>{-1.0, 6.0, -11.0, 12.0});
+    ExpectCoefficients(-polynomial,
+                       std::vector<double>{-1.0, 2.0, -3.0});
+
+    auto compoundScalar = polynomial;
+    compoundScalar += 2.0;
+    compoundScalar -= 1.0;
+    compoundScalar *= 4.0;
+    compoundScalar /= 2.0;
+    ExpectCoefficients(compoundScalar,
+                       std::vector<double>{4.0, -4.0, 6.0});
+
+    auto compoundPolynomial = polynomial;
+    compoundPolynomial += other;
+    compoundPolynomial -= other;
+    compoundPolynomial *= other;
+    ExpectCoefficients(compoundPolynomial,
+                       std::vector<double>{-1.0, 6.0, -11.0, 12.0});
+}
+
+TEST(Polynomial1D, ConversionComplexValuesAndStreamOutput) {
+    Interpolation::Polynomial1D<float> source{1.0F, 2.0F, -0.5F};
+    const Interpolation::Polynomial1D<double> converted{source};
+    ExpectCoefficients(converted, std::vector<double>{1.0, 2.0, -0.5});
+
+    using Complex = std::complex<double>;
+    const Interpolation::Polynomial1D<Complex> complexPolynomial{
+        Complex{1.0, 2.0}, Complex{2.0, -1.0}};
+    const Complex query{2.0, 0.0};
+    InterpolationTest::ExpectScaledNear(complexPolynomial(query),
+                                        Complex{5.0, 0.0});
+    InterpolationTest::ExpectScaledNear(complexPolynomial.Derivative(query),
+                                        Complex{2.0, -1.0});
+    InterpolationTest::ExpectScaledNear(complexPolynomial.Primitive(query),
+                                        Complex{6.0, 2.0});
+    InterpolationTest::ExpectScaledNear(
+        complexPolynomial.Integrate(Complex{0.0, 0.0}, query),
+        Complex{6.0, 2.0});
+
+    std::ostringstream output;
+    output << converted;
+    EXPECT_EQ(output.str(), "1 2 -0.5 ");
+}
+
+TEST(Polynomial1D, CopyMoveAndCrossTypeAssignment) {
+    using FloatPolynomial = Interpolation::Polynomial1D<float>;
+    using DoublePolynomial = Interpolation::Polynomial1D<double>;
+    using ComplexPolynomial =
+        Interpolation::Polynomial1D<std::complex<double>>;
+    static_assert(std::is_copy_assignable_v<DoublePolynomial>);
+    static_assert(std::is_move_assignable_v<DoublePolynomial>);
+
+    const FloatPolynomial source{1.0F, 2.0F, -0.5F};
+    DoublePolynomial converted{9.0, 8.0};
+    converted = source;
+    ExpectCoefficients(converted, std::vector<double>{1.0, 2.0, -0.5});
+    ExpectCoefficients(source, std::vector<float>{1.0F, 2.0F, -0.5F});
+
+    DoublePolynomial copied{7.0};
+    copied = converted;
+    ExpectCoefficients(copied, std::vector<double>{1.0, 2.0, -0.5});
+
+    DoublePolynomial moveSource{4.0, -3.0, 2.0, -1.0};
+    DoublePolynomial moved{0.0};
+    moved = std::move(moveSource);
+    ExpectCoefficients(moved,
+                       std::vector<double>{4.0, -3.0, 2.0, -1.0});
+
+    ComplexPolynomial complexAssigned{{0.0, 1.0}};
+    complexAssigned = converted;
+    ExpectCoefficients(complexAssigned,
+                       std::vector<std::complex<double>>{{1.0, 0.0},
+                                                         {2.0, 0.0},
+                                                         {-0.5, 0.0}});
+}

--- a/tests/TestUtilities.h
+++ b/tests/TestUtilities.h
@@ -1,0 +1,25 @@
+#ifndef INTERPOLATION_TEST_UTILITIES_GUARD_H
+#define INTERPOLATION_TEST_UTILITIES_GUARD_H
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <limits>
+
+namespace InterpolationTest {
+
+template <typename value_t>
+void ExpectScaledNear(const value_t &actual, const value_t &expected) {
+    using real_t = decltype(std::abs(expected));
+    const auto scale =
+        std::max<real_t>({real_t{1}, std::abs(actual), std::abs(expected)});
+    const auto tolerance =
+        real_t{1000} * std::numeric_limits<real_t>::epsilon() * scale;
+    EXPECT_LE(std::abs(actual - expected), tolerance);
+}
+
+}   // namespace InterpolationTest
+
+#endif   // INTERPOLATION_TEST_UTILITIES_GUARD_H

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -1,7 +1,75 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <limits>
+#include <vector>
+
 #include "TestCubicSpline.h"
 #include "TestLinear.h"
+
+namespace {
+
+template <typename value_t>
+void ExpectScaledNear(const value_t &actual, const value_t &expected) {
+  using real_t = decltype(std::abs(expected));
+  const auto scale = std::max<real_t>({1, std::abs(actual), std::abs(expected)});
+  const auto tolerance = 1000 * std::numeric_limits<real_t>::epsilon() * scale;
+  EXPECT_LE(std::abs(actual - expected), tolerance);
+}
+
+template <typename value_t>
+void CheckAgainstDenseReference(const std::vector<double> &x,
+                                const std::vector<value_t> &y, value_t ypl,
+                                value_t ypr) {
+  using Interpolation::CubicSpline;
+  using Interpolation::CubicSplineBC;
+  using CubicSplineTest::DenseReferenceSpline;
+  using CubicSplineTest::RecoverIntervalSecondDerivatives;
+
+  constexpr std::array boundaryConditions{
+      std::pair{CubicSplineBC::Free, CubicSplineBC::Free},
+      std::pair{CubicSplineBC::Free, CubicSplineBC::Clamped},
+      std::pair{CubicSplineBC::Clamped, CubicSplineBC::Free},
+      std::pair{CubicSplineBC::Clamped, CubicSplineBC::Clamped}};
+
+  for (const auto &[left, right] : boundaryConditions) {
+    SCOPED_TRACE(static_cast<int>(left));
+    SCOPED_TRACE(static_cast<int>(right));
+    auto spline = CubicSpline(x.begin(), x.end(), y.begin(), left, ypl, right, ypr);
+    const DenseReferenceSpline reference{x, y, left, ypl, right, ypr};
+
+    for (std::size_t i = 0; i + 1 < x.size(); ++i) {
+      for (double fraction : {0.0, 0.25, 0.5, 0.75}) {
+        const auto value = x[i] + fraction * (x[i + 1] - x[i]);
+        ExpectScaledNear(spline(value), reference(value));
+        ExpectScaledNear(spline.Derivative(value), reference.Derivative(value));
+      }
+    }
+    ExpectScaledNear(spline(x.back()), reference(x.back()));
+    ExpectScaledNear(spline.Derivative(x.back()), reference.Derivative(x.back()));
+
+    const auto first = RecoverIntervalSecondDerivatives(
+        spline, x[0], x[1], y[0], y[1]);
+    const auto lastIndex = x.size() - 1;
+    const auto last = RecoverIntervalSecondDerivatives(
+        spline, x[lastIndex - 1], x[lastIndex], y[lastIndex - 1], y[lastIndex]);
+    if (left == CubicSplineBC::Free) {
+      ExpectScaledNear(first.first, value_t{});
+    } else {
+      ExpectScaledNear(spline.Derivative(x.front()), ypl);
+    }
+    if (right == CubicSplineBC::Free) {
+      ExpectScaledNear(last.second, value_t{});
+    } else {
+      ExpectScaledNear(spline.Derivative(x.back()), ypr);
+    }
+  }
+}
+
+}  // namespace
 
 // Tests for linear interpolation
 
@@ -65,4 +133,50 @@ TEST(CubicSpline, CheckComplexDouble) {
 TEST(CubicSpline, CheckComplexLongDouble) {
   int i = CubicSplineCheck<long double, std::complex<long double>>();
   EXPECT_EQ(0, i);
+}
+
+TEST(CubicSpline, NaturalNonuniformKnownAnswer) {
+  const std::vector<double> x{0.0, 1.0, 3.0, 4.0};
+  const std::vector<double> y{0.0, 1.0, 0.0, 2.0};
+  const Interpolation::CubicSpline spline{x.begin(), x.end(), y.begin()};
+
+  struct Sample {
+    double x;
+    double value;
+    double derivative;
+  };
+  constexpr std::array samples{
+      Sample{0.5, 0.6640625, 1.109375},
+      Sample{2.0, 0.3125, -1.0},
+      Sample{3.5, 0.7890625, 2.140625}};
+
+  for (const auto &sample : samples) {
+    ExpectScaledNear(spline(sample.x), sample.value);
+    ExpectScaledNear(spline.Derivative(sample.x), sample.derivative);
+  }
+
+  const auto first = CubicSplineTest::RecoverIntervalSecondDerivatives(
+      spline, x[0], x[1], y[0], y[1]);
+  const auto last = CubicSplineTest::RecoverIntervalSecondDerivatives(
+      spline, x[2], x[3], y[2], y[3]);
+  ExpectScaledNear(first.first, 0.0);
+  ExpectScaledNear(last.second, 0.0);
+}
+
+TEST(CubicSpline, BoundaryCombinationsMatchDenseReference) {
+  CheckAgainstDenseReference<double>({0.0, 1.0, 3.0, 4.0},
+                                     {0.0, 1.0, 0.0, 2.0}, -0.5, 1.25);
+}
+
+TEST(CubicSpline, TwoPointBoundaryCombinationsMatchDenseReference) {
+  CheckAgainstDenseReference<double>({0.0, 2.0}, {1.0, 4.0}, -0.5, 1.25);
+}
+
+TEST(CubicSpline, ComplexBoundaryCombinationsMatchDenseReference) {
+  using Complex = std::complex<double>;
+  CheckAgainstDenseReference<Complex>(
+      {0.0, 1.0, 3.0, 4.0},
+      {Complex{0.0, 1.0}, Complex{1.0, -0.5}, Complex{0.0, 0.25},
+       Complex{2.0, -1.0}},
+      Complex{-0.5, 0.75}, Complex{1.25, -0.25});
 }

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <complex>
 #include <limits>
+#include <utility>
 #include <vector>
 
 #include "TestCubicSpline.h"


### PR DESCRIPTION
Mainly codex changes. Main things:

1. CubicSpline used SimplicialLDLT, but the matrix wasn't actually symmetric. The endpoints for free BC weren't effectively set to zero and this meant that it was slightly different to standard spline.

2. A few minor changes to Akima and others for improved handling of domain values near boundaries or outside

3. More tests, against cubic functions as well as some other tests. 

4. More complete doxygen comments and documentation