### PR TITLE
Answer the four asks from GSHTrans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, refactor]
+    branches: [main, develop, refactor]
   pull_request:
   workflow_dispatch:
 
@@ -18,6 +18,12 @@ jobs:
   # The test suite is the behavioural oracle for the refactor. Warnings are
   # errors here, but only on our own targets: dependencies are fetched SYSTEM
   # so their headers are not held to our flags.
+  #
+  # GCC 13 is in the matrix because it is what the deployment target for the
+  # codes GSHTrans serves actually has. Nothing here needs fixing for it today;
+  # the leg exists so that it stays that way by construction. The one decision
+  # that would break it is deducing `this`, which GCC 13 lacks and which no
+  # header uses — a compiler is a better guard on that than an inspection.
   # ---------------------------------------------------------------------------
   build-and-test:
     name: ${{ matrix.compiler }} (${{ matrix.build_type }})
@@ -25,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [g++-14, clang++-18]
+        compiler: [g++-13, g++-14, clang++-18]
         build_type: [Release, Debug]
 
     steps:
@@ -34,11 +40,10 @@ jobs:
       - name: Install the compiler
         run: |
           sudo apt-get update
-          if [ "${{ matrix.compiler }}" = "g++-14" ]; then
-            sudo apt-get install -y g++-14
-          else
-            sudo apt-get install -y clang-18
-          fi
+          case "${{ matrix.compiler }}" in
+            clang++-18) sudo apt-get install -y clang-18 ;;
+            *)          sudo apt-get install -y "${{ matrix.compiler }}" ;;
+          esac
 
       - name: Cache FetchContent dependencies
         uses: actions/cache@v4
@@ -65,7 +70,7 @@ jobs:
       # counts agree.
       - name: Check the oracle is intact
         run: |
-          expected=92
+          expected=119
           count=$(ctest --test-dir build -N | sed -n 's/^Total Tests: //p')
           echo "Discovered $count tests, expected at least $expected."
           if [ "$count" -lt "$expected" ]; then
@@ -161,6 +166,7 @@ jobs:
           cat > consumer/main.cpp <<'CPP'
           #include <Interpolation/Interpolation.hpp>
           #include <cstdio>
+          #include <span>
           #include <utility>
           #include <vector>
 
@@ -175,6 +181,24 @@ jobs:
           int main() {
               const auto s = MakeSpline();
               std::printf("%.6f %.6f\n", s(1.5), s.Evaluate<1>(1.5));
+
+              // The shared-factorisation path, so that its headers are known
+              // to reach an install tree and not only the build tree.
+              const std::vector<double> x{0.0, 1.0, 2.0, 3.0};
+              const std::vector<double> y{0.0, 1.0, 4.0, 9.0};
+              const auto system = Interpolation::CubicSplineSystem{x};
+              std::vector<double> curvature(x.size()), slope(x.size());
+              system.Solve(y, std::span{curvature});
+              system.EvaluateAtNodes<1>(y, curvature, std::span{slope});
+
+              const Interpolation::CubicSpline reference{x, y};
+              for (std::size_t i = 0; i < x.size(); ++i) {
+                  if (slope[i] != reference.Evaluate<1>(x[i])) {
+                      std::printf("nodal sweep disagreed at node %zu\n", i);
+                      return 1;
+                  }
+              }
+              std::printf("nodal sweep agrees at every node\n");
               return 0;
           }
           CPP

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,6 +1,10 @@
 {
   "version": 6,
-  "cmakeMinimumRequired": { "major": 3, "minor": 24, "patch": 0 },
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 24,
+    "patch": 0
+  },
   "configurePresets": [
     {
       "name": "base",
@@ -9,6 +13,15 @@
       "cacheVariables": {
         "INTERPOLATION_BUILD_TESTS": "ON",
         "INTERPOLATION_BUILD_EXAMPLES": "ON"
+      }
+    },
+    {
+      "name": "gcc-13",
+      "inherits": "base",
+      "displayName": "GCC 13, Release (the deployment-target compiler)",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++-13",
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
@@ -33,7 +46,9 @@
       "name": "debug",
       "inherits": "base",
       "displayName": "Default compiler, Debug",
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
     },
     {
       "name": "asan",
@@ -57,22 +72,69 @@
     }
   ],
   "buildPresets": [
-    { "name": "gcc-14",   "configurePreset": "gcc-14" },
-    { "name": "clang-18", "configurePreset": "clang-18" },
-    { "name": "debug",    "configurePreset": "debug" },
-    { "name": "asan",     "configurePreset": "asan" },
-    { "name": "docs",     "configurePreset": "docs", "targets": ["InterpolationDocs"] }
+    {
+      "name": "gcc-13",
+      "configurePreset": "gcc-13"
+    },
+    {
+      "name": "gcc-14",
+      "configurePreset": "gcc-14"
+    },
+    {
+      "name": "clang-18",
+      "configurePreset": "clang-18"
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "asan",
+      "configurePreset": "asan"
+    },
+    {
+      "name": "docs",
+      "configurePreset": "docs",
+      "targets": [
+        "InterpolationDocs"
+      ]
+    }
   ],
   "testPresets": [
     {
       "name": "base",
       "hidden": true,
-      "output": { "outputOnFailure": true },
-      "execution": { "noTestsAction": "error" }
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error"
+      }
     },
-    { "name": "gcc-14",   "inherits": "base", "configurePreset": "gcc-14" },
-    { "name": "clang-18", "inherits": "base", "configurePreset": "clang-18" },
-    { "name": "debug",    "inherits": "base", "configurePreset": "debug" },
-    { "name": "asan",     "inherits": "base", "configurePreset": "asan" }
+    {
+      "name": "gcc-13",
+      "inherits": "base",
+      "configurePreset": "gcc-13"
+    },
+    {
+      "name": "gcc-14",
+      "inherits": "base",
+      "configurePreset": "gcc-14"
+    },
+    {
+      "name": "clang-18",
+      "inherits": "base",
+      "configurePreset": "clang-18"
+    },
+    {
+      "name": "debug",
+      "inherits": "base",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "asan",
+      "inherits": "base",
+      "configurePreset": "asan"
+    }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ noted below. The library has no external dependencies.
 | `Lagrange` | Global polynomial interpolation of sampled values | 1 node |
 | `LagrangeBasis` | Individual Lagrange cardinal basis functions | 1 node |
 | `Polynomial` | Polynomial evaluation, calculus, and arithmetic | Defaults to zero; otherwise 1 coefficient |
+| `CubicSplineSystem` | The spline system for a fixed grid, factorised once and reused across datasets | 2 nodes |
+| `TridiagonalFactorization` | A tridiagonal matrix reduced once, ready to act on many right-hand sides | 1 row |
 
 Two-dimensional interpolation on rectilinear grids:
 
@@ -37,7 +39,7 @@ strictly increasing, and this is enforced at construction.
 
 ## Requirements
 
-- A C++23 compiler. GCC 14 and Clang 18 are the versions CI covers
+- A C++23 compiler. GCC 13, GCC 14 and Clang 18 are the versions CI covers
 - CMake 3.24 or newer
 - No external dependencies. Git access is needed only when CMake fetches
   GoogleTest to build the tests
@@ -54,7 +56,9 @@ cmake --build --preset gcc-14
 ctest --preset gcc-14
 ```
 
-`clang-18`, `debug`, `asan` and `docs` presets are also available.
+`gcc-13`, `clang-18`, `debug`, `asan` and `docs` presets are also
+available. The `gcc-13` leg exists because that is the compiler on the
+deployment target for the codes the consuming libraries serve.
 
 ## Use from CMake
 
@@ -249,12 +253,61 @@ running one tells you immediately whether it did the right thing.
 | `08-derivatives-and-integrals` | `Primitive`, and integrals that are exact |
 | `09-piecewise-layers` | Discontinuities, extracting a layer, mixed kinds |
 | `10-two-dimensions` | Grids, mixed partials, why the edge condition matters |
+| `11-one-grid-many-datasets` | Factorising a grid once, and evaluating at every node |
 
 ```sh
 cmake --preset gcc-14
 cmake --build --preset gcc-14 --target examples
 ./build/gcc-14/examples/03-boundary-conditions
 ```
+
+## One grid, many datasets
+
+A cubic spline's matrix depends on the nodes alone; only the right-hand side
+carries the ordinates. So a caller holding many datasets on one grid — the
+components of a field, an ensemble of profiles, a line of spectral
+coefficients — should factorise once and solve many times rather than
+construct a spline per dataset. `CubicSplineSystem` names that, and
+`CubicSpline` is built on it, so there is one assembly of the spline equations
+rather than one per caller.
+
+```cpp
+#include <Interpolation/CubicSplineSystem.hpp>
+
+const auto system = Interpolation::CubicSplineSystem{
+    radius, Interpolation::BoundaryCondition::NotAKnot};   // factorised here
+
+std::vector<std::complex<double>> curvature(radius.size());
+std::vector<std::complex<double>> derivative(radius.size());
+
+for (const auto& line : lines) {
+    system.Solve(line, std::span{curvature});
+    system.EvaluateAtNodes<1>(line, curvature, std::span{derivative});
+}
+```
+
+`Solve` and `EvaluateAtNodes` both write into storage the caller owns and are
+`const`, so the loop allocates nothing and a fixed system may be shared across
+threads. The matrix is real even when the ordinates are complex, so the
+ordinate type is a parameter of `Solve` rather than of the class: one system
+serves both. A spline that has already been built hands its system back
+through `SplineSystem()`.
+
+The other half of the same idea is `EvaluateAtNodes`, which every
+one-dimensional interpolator offers: evaluating at the nodes is the one query
+that needs no search, since the segment adjoining each node is known.
+
+```cpp
+const Interpolation::CubicSpline spline{x, y};
+const auto slopes = spline.NodeValues<1>();               // allocating form
+spline.EvaluateAtNodes<1>(std::span{buffer});             // into your storage
+```
+
+A value at a node agrees from both sides, but a high enough derivative need
+not — the third for a cubic, the first for a piecewise-linear interpolant.
+Evaluation is right-continuous throughout the library, so the default reports
+the limit from the segment starting at the node, and `Side::Left` asks for the
+other. `Piecewise` uses the same convention across its breakpoints.
 
 ## Build, test, and document
 
@@ -298,3 +351,14 @@ directly by the Thomas algorithm. The system is strictly diagonally dominant,
 so no pivoting is required. Its coefficients are real even when the ordinates
 are complex, so a complex spline solves a real system against a complex
 right-hand side.
+
+Natural and Clamped are assembled in the nodal-curvature formulation and
+solved for what the evaluator wants. Not-a-knot is assembled in nodal slopes
+and converted afterwards: written directly in curvatures its boundary row
+reaches outside the tridiagonal band, and eliminating that entry leaves a
+leading coefficient of `h0^2 - h1^2`, which vanishes on a uniform grid. In
+slopes the diagonal of that row is `h1 > 0` for any spacing.
+
+Both the assembled system and the tridiagonal solver behind it are public:
+`CubicSplineSystem` for the spline case, `TridiagonalFactorization` and
+`SolveTridiagonal` for a caller with a banded system of their own.

--- a/benchmarks/Benchmarks.cpp
+++ b/benchmarks/Benchmarks.cpp
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <numeric>
 #include <random>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -297,6 +298,68 @@ main() {
                 worst, RelativeDifference(dense[i], spline.Evaluate<2>(x[i])));
         }
         Row("CubicSpline construction", n, before, after, worst);
+    }
+
+    // One grid, many datasets: the shape a radial differentiation operator
+    // has. The replaced form is a spline per line and a binary search per
+    // node; the current one factorises the grid once and sweeps the nodes.
+    for (const std::size_t n : {9u, 33u, 129u}) {
+        constexpr std::size_t lineCount = 512;
+        const auto [x, unused] = MakeSamples(n, 20260823ull);
+        (void) unused;
+
+        std::vector<std::vector<double>> lines;
+        lines.reserve(lineCount);
+        for (std::size_t line = 0; line < lineCount; ++line) {
+            const auto [ignored, y] =
+                MakeSamples(n, 20260823ull + 7919ull * line);
+            (void) ignored;
+            lines.push_back(y);
+        }
+
+        const auto before = BestOf(repetitions, [&] {
+            double total = 0.0;
+            for (const auto &line : lines) {
+                const Interpolation::CubicSpline spline{x, line};
+                for (std::size_t i = 0; i < n; ++i) {
+                    total += spline.Evaluate<1>(x[i]);
+                }
+            }
+            g_sink = total;
+        });
+
+        const auto after = BestOf(repetitions, [&] {
+            // The factorisation is inside the timed region, so it is paid for
+            // exactly once and the comparison stays honest.
+            const Interpolation::CubicSplineSystem system{x};
+            std::vector<double> curvature(n), derivative(n);
+            double total = 0.0;
+            for (const auto &line : lines) {
+                system.Solve(line, std::span<double>{curvature});
+                system.EvaluateAtNodes<1>(line, curvature,
+                                          std::span<double>{derivative});
+                for (std::size_t i = 0; i < n; ++i) {
+                    total += derivative[i];
+                }
+            }
+            g_sink = total;
+        });
+
+        const Interpolation::CubicSplineSystem system{x};
+        std::vector<double> curvature(n), derivative(n);
+        double worst = 0.0;
+        for (const auto &line : lines) {
+            const Interpolation::CubicSpline spline{x, line};
+            system.Solve(line, std::span<double>{curvature});
+            system.EvaluateAtNodes<1>(line, curvature,
+                                      std::span<double>{derivative});
+            for (std::size_t i = 0; i < n; ++i) {
+                worst = std::max(worst,
+                                 RelativeDifference(derivative[i],
+                                                    spline.Evaluate<1>(x[i])));
+            }
+        }
+        Row("d/dx at nodes, 512 lines", n, before, after, worst);
     }
 
     std::printf(

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -7,7 +7,11 @@ INPUT                  = "@CMAKE_CURRENT_SOURCE_DIR@/include" \
                          "@CMAKE_CURRENT_SOURCE_DIR@/docs"
 FILE_PATTERNS          = *.hpp *.md
 RECURSIVE              = YES
-EXCLUDE_PATTERNS       = */build/* */_deps/*
+# The hand-over notes exchanged with the consuming libraries are prose about a
+# relationship between repositories, not API reference, and they name members
+# in running text ("RadialInterpolation::CubicSpline()") that Doxygen reads as
+# explicit link requests it cannot resolve. They are read on GitHub, not here.
+EXCLUDE_PATTERNS       = */build/* */_deps/* */*-for-GSHTrans.md
 EXAMPLE_PATH           = "@CMAKE_CURRENT_SOURCE_DIR@/examples"
 USE_MDFILE_AS_MAINPAGE = "@CMAKE_CURRENT_SOURCE_DIR@/README.md"
 STRIP_FROM_PATH        = "@CMAKE_CURRENT_SOURCE_DIR@"

--- a/docs/Interpolation-for-GSHTrans.md
+++ b/docs/Interpolation-for-GSHTrans.md
@@ -1,0 +1,188 @@
+# Interpolation — what GSHTrans found using it
+
+A hand-over note in the other direction from `GaussQuad-for-GSHTrans.md` and
+`FFTWpp-for-GSHTrans.md`: those record what GSHTrans needed to know about a
+dependency, and this records what a consumer learned from `da380/Interpolation`
+at `main` (`56c2fe9`, 2026-08-22) and what would make it more useful. Everything
+below was compiled or measured on this machine rather than read off the
+interface.
+
+**Short version: it is in, it is used, and nothing has to change. There is one
+request worth considering, one cheap piece of CI insurance, and one convention
+we now depend on and would like to keep depending on.**
+
+---
+
+## 1. How GSHTrans uses it now
+
+An **optional dependency, on by default**: `GSHTRANS_WITH_INTERPOLATION`,
+fetched-or-found in the same pattern as NumericConcepts, GaussQuad and FFTWpp,
+tracking `main` as they do. A build with it off compiles, fetches nothing, and
+runs 273 of the 280 tests.
+
+It is used in exactly two places.
+
+- **`Resample`** — carrying a three-dimensional field from one set of radii to
+  another. `RadialInterpolation::Linear()`, `::CubicSpline()` and `::Akima()`
+  are the policy, so the whole menu costs a policy argument rather than three
+  implementations. This is the one runtime use.
+- **As an oracle in the tests.** `SplineDerivative` is checked against
+  `Interpolation::CubicSpline` on data with no polynomial structure, real and
+  complex, to `1e-12`. An independent implementation of the same spline is a
+  stronger check than any property GSHTrans could assert about its own.
+
+It is deliberately **not** used for the three ready-made radial derivatives,
+which are self-contained. §3 is why, and it is the substance of this note.
+
+---
+
+## 2. What was checked and is fine
+
+- **The interpolators take complex ordinates.** `InterpolationRanges` requires
+  `RealOrComplexRange` for the ordinates, so a radial line of spherical-harmonic
+  coefficients goes in directly with no real/imaginary split. Verified by
+  compiling `CubicSpline` and `AkimaSpline` over `std::complex<double>`. This
+  matters more than it sounds: the model application does all of its radial work
+  in the spectral domain, where every line is complex.
+- **The dependency set is `NumericConcepts` and nothing else**, which GSHTrans
+  already has. So it adds no transitive dependency at all — the reason making it
+  optional was almost not worth doing.
+- **Install and export work.** `Interpolation::Interpolation` is exported and
+  the install rules are unconditional, so a copy fetched into a GSHTrans build
+  installs itself and `find_package(GSHTrans)` still resolves. Two of the other
+  three dependencies had to be changed before they could do that; this one
+  needed nothing.
+- **The lifetime rule matches ours.** Borrow an lvalue, own an rvalue, is
+  exactly the operand-storage rule GSHTrans chose for expression nodes and for
+  the same reason. Arrived at independently, and it means a value can cross
+  between the libraries under one rule rather than two.
+
+---
+
+## 3. The request: the node-dependent part is separable, and only you can
+expose it
+
+This is the one that changed what GSHTrans built.
+
+**What happened.** GSHTrans needed `d/dr` of a spline through each radial line
+of a field. A radial operator is called **once per line** — `nθ · nφ` in the
+spatial domain, or about 66,000 coefficients at `lMax = 256` in the spectral
+one — so the natural spelling is a `CubicSpline` per line. Two things make that
+more expensive than it needs to be, and neither is a defect:
+
+- construction computes the coefficients and holds them in a `std::vector`, so
+  it costs about four allocations; and
+- `Evaluate` locates its segment by binary search, so asking for the derivative
+  at every node of the curve just fitted costs `nR log nR` lookups.
+
+Both are the right design for what the interface is *for* — evaluating a curve
+at a point. They are simply the wrong shape for "give me the derivative at
+every node", which is what a differentiation operator is.
+
+**The observation that matters:** for a fixed set of abscissae, the spline
+system's **matrix depends on the nodes alone**. Only the right-hand side carries
+the ordinates. So a caller with many ordinate sets on one grid — multi-component
+data, an ensemble, a field of coefficients — can factorise once and solve many
+times, and that is a common shape rather than a GSHTrans quirk.
+
+**Measured**, over 66,049 lines, a spline constructed per line against an
+operator that reuses its factorisation:
+
+| `nR` | per line | reused factorisation | ratio |
+|---:|---:|---:|---:|
+| 9 | 13.9 ms | 6.8 ms | 2.0× |
+| 17 | 23.0 ms | 13.8 ms | 1.7× |
+| 33 | 58.4 ms | 27.8 ms | 2.1× |
+| 65 | 73.4 ms | 61.2 ms | 1.2× |
+| 129 | 193.6 ms | 137.4 ms | 1.4× |
+| 257 | 401.9 ms | 296.9 ms | 1.4× |
+
+**So it is 1.2× to 2×, and not more.** That is worth being honest about,
+because the first version of this argument inside GSHTrans put it much higher
+and was wrong. A 1.4× on an operation applied every iteration of a matrix-free
+solve is still worth avoiding, but it is not the headline.
+
+**The headline is the duplication.** Because there was no way to reach the
+factorisation, GSHTrans now contains its own natural-cubic-spline system and
+its own Thomas sweep. That is about sixty lines that exist only because
+`Interpolation::Detail::SolveTridiagonal` is in `Detail` — a function that is
+fully documented, typed so a real matrix can act on a complex right-hand side,
+and carries its own no-pivoting argument from diagonal dominance. It reads like
+considered public API that happens to be namespaced private. Two implementations
+of one spline, in two repositories with one author, is the cost actually worth
+avoiding.
+
+**Two ways to fix it, smallest first.**
+
+1. **Promote `SolveTridiagonal`.** One namespace change. GSHTrans would delete
+   its Thomas sweep and keep its own assembly of the system.
+2. **Expose the factorisation itself** — something like
+   `CubicSplineSystem<Real>(abscissae)` with `Solve(ordinates, secondDerivatives)`,
+   which `CubicSpline` would then use internally. GSHTrans would delete all
+   sixty lines. This is the better shape for the library too: it names the thing
+   that is reusable, and it makes "one grid, many datasets" a first-class case
+   rather than something a caller has to notice.
+
+A third, orthogonal and smaller: **an "evaluate at the nodes" path** that
+returns the value or derivative at every abscissa without a binary search per
+point. That is the other half of what a differentiation operator wants.
+
+---
+
+## 4. Cheap insurance: a GCC 13 leg in CI
+
+CI covers GCC 14 and Clang 18. The deployment target for the codes GSHTrans
+serves — `earth-tunya` — has **GCC 13.2**, and current `main` compiles there:
+verified with `g++-13 -std=c++23`, including `CubicSpline`, `AkimaSpline` and
+`LagrangeBasis` instantiated over `std::complex<double>`.
+
+So this is locking in something that already works rather than asking for a
+fix. The roadmap's decision to use deducing `this` — which GCC 13 lacks — is
+the thing that would break it, and no use of it survived into the headers; a CI
+leg is what would keep that true by accident rather than by inspection.
+
+---
+
+## 5. A convention we now depend on, deliberately
+
+`Piecewise` is exactly what it says, checked against current `main`:
+breakpoints strictly increasing and one longer than the pieces, the pieces
+tiling with no gaps, continuity across a breakpoint **not** checked, evaluation
+right-continuous so piece `k` owns `[b_k, b_{k+1})`, and `Limits(x)` returning
+both one-sided values.
+
+GSHTrans has just adopted all of that. Its `RadialGrid` can now carry an element
+partition, and the representation was chosen to *be* breakpoints in that sense:
+blocks are disjoint, two elements meet at a repeated radius, both one-sided
+derivatives exist there, and continuity is the caller's business rather than
+something the grid enforces. The reasoning is in
+`docs/field-algebra-plan.md` §20.
+
+The point of saying so: the two libraries should not be able to disagree about
+what happens at the core–mantle boundary, and that agreement is now load-bearing
+for a consumer rather than a coincidence. If the right-continuity convention or
+`Limits` ever moves, GSHTrans wants to know.
+
+---
+
+## 6. Not your problem
+
+Recorded so it is not mistaken for a request. `Interpolation` requires CMake
+3.24. GSHTrans declares 3.20 while already using `FIND_PACKAGE_ARGS`, which is
+itself a 3.24 feature, so GSHTrans's stated minimum has been wrong since before
+this dependency existed. That is a one-line fix on the GSHTrans side and no
+constraint on yours.
+
+---
+
+## 7. Summary of what is being asked
+
+| | ask | size | why |
+|---|---|---|---|
+| 1 | Expose the spline factorisation, or at least promote `SolveTridiagonal` | small | deletes a duplicated implementation; 1.2–2× where it is used |
+| 2 | An evaluate-at-the-nodes path | small | avoids a binary search per node for the case that has none to do |
+| 3 | A GCC 13 leg in CI | trivial | a known deployment target, already passing |
+| 4 | Keep `Piecewise`'s conventions | none | a consumer now depends on them |
+
+Nothing here blocks GSHTrans. The dependency is in, on by default, and doing
+useful work as it stands.

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,9 +56,11 @@ tree.
 
 ## Benchmarks
 
-The two algorithmic changes in phase 2 have a harness that measures them
-against the implementations they replaced, rather than resting on complexity
-arguments:
+The algorithmic changes made here have a harness that measures them against
+the implementations they replaced, rather than resting on complexity
+arguments. It covers barycentric `Lagrange`, the tridiagonal spline solve, and
+the shared-factorisation path for a nodal derivative over many lines on one
+grid:
 
 ```sh
 cmake -S . -B build -DINTERPOLATION_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release
@@ -73,10 +75,16 @@ answers is visible rather than hidden.
 
 ## Continuous integration
 
-CI builds the gcc-14 and clang-18 matrix across Release and Debug with
+CI builds the gcc-13, gcc-14 and clang-18 matrix across Release and Debug with
 warnings as errors, runs an ASan and UBSan job, checks formatting with
 clang-format 18, builds the documentation, and installs the package to verify
 that a separate consumer project can find it through `find_package`.
+
+GCC 13 is in the matrix because it is the compiler on the deployment target
+for the codes the consuming libraries serve. Nothing needs fixing for it; the
+leg exists so that it stays that way by construction rather than by
+inspection. The one decision that would break it is deducing `this`, which
+GCC 13 lacks and which no header uses.
 
 Reproduce any of these locally with the matching preset before pushing.
 

--- a/docs/interpolation-methods.md
+++ b/docs/interpolation-methods.md
@@ -43,6 +43,43 @@ tridiagonal system for the nodal second derivatives and solves it with the
 Thomas algorithm, without pivoting, which is safe because the system is
 strictly diagonally dominant.
 
+### The system is separable from the data
+
+That matrix depends on the nodes alone; only the right-hand side carries the
+ordinates. `CubicSplineSystem` is that matrix, assembled and eliminated once,
+with `Solve` applying it to any number of ordinate sets. `CubicSpline` holds
+one and is solved by it, so the spline equations are assembled in exactly one
+place, and `BicubicSpline` builds one system per axis rather than one per line.
+
+The separation is worth naming because "one grid, many datasets" is a common
+shape rather than a special case: the components of a vector field, an
+ensemble of profiles, a line of spectral coefficients at every point of a
+sphere. A caller in that position pays for the factorisation once. `Solve`
+allocates nothing and is `const`, so a fixed system can be shared across
+threads, and because the matrix is real even for complex ordinates the
+ordinate type is a parameter of `Solve` rather than of the class.
+
+`TridiagonalFactorization` sits underneath and is public in its own right, for
+a caller who assembles a different banded system; `SolveTridiagonal` remains
+for the genuinely one-shot case, where keeping the pivots would be waste.
+
+### Evaluating at the nodes
+
+Every one-dimensional interpolator offers `EvaluateAtNodes<N>` and
+`NodeValues<N>`. Evaluating at a node is the one query that needs no search,
+since the segment adjoining each node is known, so the nodal sweep costs a
+single pass where the general path would cost `n log n` lookups. That is the
+other half of what a differentiation operator on a fixed grid wants, and
+`CubicSplineSystem` offers it too, taking the ordinates and curvatures rather
+than holding them.
+
+A value at a node agrees from both sides, as do the first and second
+derivatives of a cubic spline; the third jumps, as does the first derivative of
+a piecewise-linear interpolant. `Side` chooses which limit is reported, and
+defaults to the right-hand one, so the nodal sweep agrees with an ordinary
+query at the same abscissa. This is the same convention `Piecewise` uses across
+its breakpoints, and it is deliberately the only one in the library.
+
 Use a cubic spline for smooth material profiles or other data where continuous
 first and second derivatives matter. Exterior evaluation continues the first
 or final cubic piece and should not be interpreted as a physically constrained

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -241,6 +241,56 @@ order, about 770x better than natural at 65 by 65 on sin(x)cos(y).
 `AnyFunction1D` supplies the type erasure that gives `Piecewise` mixed piece
 kinds, and the examples are a numbered series in `examples/`.
 
+### Phase 5 - What a consumer found
+
+The first phase driven from outside rather than from this plan. GSHTrans
+adopted the library, used it in anger, and wrote up what it learned in
+`docs/Interpolation-for-GSHTrans.md`. Four asks came back, and all four are
+done.
+
+**The factorisation is now reachable.** The observation behind the ask is that
+a cubic spline's matrix depends on the nodes alone, so a caller with many
+ordinate sets on one grid can factorise once and solve many times — and
+GSHTrans, lacking any way to reach it, had grown its own copy of the spline
+system and a Thomas sweep to go with it. Two implementations of one spline in
+two repositories with one author is the cost worth avoiding, well ahead of the
+1.2x to 2x it measured.
+
+`CubicSplineSystem` is that matrix, and `TridiagonalFactorization` is the
+reduced form underneath it, both public. The elimination happens once at
+construction and keeps its pivots, which the previous one-shot solver
+destroyed; `Solve` is then a forward sweep and a back substitution with no
+division at all, allocating nothing and `const` so a fixed system is shareable
+across threads. `CubicSpline` is built on it, so the spline equations are
+assembled in one place rather than one per caller, and `BicubicSpline` now
+builds one system per axis instead of one per line.
+
+**Evaluating at the nodes no longer searches.** `EvaluateAtNodes<N>` and
+`NodeValues<N>` on every one-dimensional interpolator, and on
+`CubicSplineSystem` for a caller working from ordinates and curvatures
+directly. The sided cases — the third derivative of a cubic, the first of a
+piecewise-linear interpolant — take the `Side` that `Piecewise` already
+defined, moved to its own header so one convention covers breakpoints and
+nodes alike.
+
+**GCC 13 is in the CI matrix**, because it is what the deployment target for
+the codes GSHTrans serves actually has. Nothing needed fixing; the leg keeps
+it that way by construction.
+
+**`Piecewise`'s conventions are pinned by tests** rather than holding by
+construction. A consumer has built its own element partition to match them, so
+right-continuity, the ordering of `Limits`, gapless tiling, and the deliberate
+absence of a continuity check are now stated in a `PiecewiseContract` group
+that fails here if any of them moves.
+
+**Exit:** the suite goes 92 to 119 tests, green on GCC 13, GCC 14 and Clang
+18, with the new curvatures bit-for-bit identical to what the old code
+produced.
+
+Status: done. Measured on this machine at 512 lines per grid, the shared
+factorisation with a nodal sweep runs 2.8x to 5.0x the spline-per-line path
+and agrees with it to zero relative difference.
+
 ## Correctness items folded into the above
 
 - Compiling the headers with `-Wall -Wextra` surfaces two unused variables in

--- a/examples/11-one-grid-many-datasets.cpp
+++ b/examples/11-one-grid-many-datasets.cpp
@@ -1,0 +1,109 @@
+// 11 - One grid, many datasets
+//
+// A cubic spline's matrix depends on the nodes alone; only the right-hand side
+// carries the ordinates. So a caller with many datasets on one grid should
+// factorise once and solve many times, and ask for the derivative at every
+// node in one sweep rather than searching for segments it already knows.
+//
+// That is what CubicSplineSystem is for, and it is the shape a radial
+// differentiation operator has: one grid, one line of data per column of a
+// field, applied over and over.
+
+#include <Interpolation/CubicSpline.hpp>
+#include <Interpolation/CubicSplineSystem.hpp>
+
+#include <chrono>
+#include <cmath>
+#include <complex>
+#include <cstdio>
+#include <span>
+#include <vector>
+
+int
+main() {
+    using namespace Interpolation;
+    using Complex = std::complex<double>;
+
+    // A radial grid, and a field of complex coefficients sampled on it: one
+    // line per coefficient, all sharing the same nodes.
+    constexpr std::size_t nodeCount = 65;
+    constexpr std::size_t lineCount = 2000;
+
+    std::vector<double> radius;
+    for (std::size_t i = 0; i < nodeCount; ++i) {
+        // Deliberately uneven, thickening towards the surface.
+        const double t = static_cast<double>(i) / (nodeCount - 1);
+        radius.push_back(3480.0 + 2891.0 * t * t);
+    }
+
+    std::vector<std::vector<Complex>> lines(lineCount,
+                                            std::vector<Complex>(nodeCount));
+    for (std::size_t line = 0; line < lineCount; ++line) {
+        const double k = 1.0 + 0.01 * static_cast<double>(line);
+        for (std::size_t i = 0; i < nodeCount; ++i) {
+            const double s = (radius[i] - 3480.0) / 2891.0;
+            lines[line][i] = Complex{std::sin(k * s), std::cos(k * s)};
+        }
+    }
+
+    std::printf("A field of %zu complex lines on one grid of %zu nodes.\n\n",
+                lineCount, nodeCount);
+
+    // The matrix is assembled and eliminated once, here. Everything after
+    // this point is arithmetic on a right-hand side.
+    const auto system = CubicSplineSystem{radius, BoundaryCondition::NotAKnot};
+
+    // Two buffers for the whole sweep, not two per line. Solve and
+    // EvaluateAtNodes both write into storage the caller owns, so the loop
+    // below allocates nothing at all.
+    std::vector<Complex> curvature(nodeCount);
+    std::vector<Complex> derivative(nodeCount);
+
+    const auto start = std::chrono::steady_clock::now();
+    double checksum = 0.0;
+    for (const auto &line : lines) {
+        system.Solve(line, std::span{curvature});
+        system.EvaluateAtNodes<1>(line, curvature, std::span{derivative});
+        checksum += std::abs(derivative[nodeCount / 2]);
+    }
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    std::printf("  d/dr at every node of every line: %.2f ms\n",
+                std::chrono::duration<double, std::milli>(elapsed).count());
+    std::printf("  checksum %.6f\n\n", checksum);
+
+    // The same numbers, the long way round: a fresh spline per line, and a
+    // query per node. Both re-do work the grid already determined.
+    const auto slowStart = std::chrono::steady_clock::now();
+    double slowChecksum = 0.0;
+    for (const auto &line : lines) {
+        const CubicSpline spline{radius, line, BoundaryCondition::NotAKnot,
+                                 Complex{}, Complex{}};
+        for (std::size_t i = 0; i < nodeCount; ++i) {
+            const auto d = spline.Evaluate<1>(radius[i]);
+            if (i == nodeCount / 2) {
+                slowChecksum += std::abs(d);
+            }
+        }
+    }
+    const auto slowElapsed = std::chrono::steady_clock::now() - slowStart;
+
+    std::printf("  a spline and a search per line:   %.2f ms\n",
+                std::chrono::duration<double, std::milli>(slowElapsed).count());
+    std::printf("  checksum %.6f\n\n", slowChecksum);
+
+    // Identical answers: this is a reorganisation, not an approximation.
+    std::printf("The two agree to %.1e.\n\n",
+                std::abs(checksum - slowChecksum));
+
+    // A spline that has already been built hands its factorisation back, for
+    // the case where the second dataset turns up after the first fit.
+    const CubicSpline first{radius, lines[0], BoundaryCondition::NotAKnot,
+                            Complex{}, Complex{}};
+    const auto reused = first.SplineSystem().Curvatures(lines[1]);
+    std::printf("Reusing one spline's system on another line gives %zu "
+                "curvatures without rebuilding the matrix.\n",
+                reused.size());
+
+    return 0;
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,7 +12,8 @@ set(INTERPOLATION_EXAMPLES
     07-function-algebra
     08-derivatives-and-integrals
     09-piecewise-layers
-    10-two-dimensions)
+    10-two-dimensions
+    11-one-grid-many-datasets)
 
 foreach(example IN LISTS INTERPOLATION_EXAMPLES)
   add_executable(${example} ${example}.cpp)

--- a/include/Interpolation/AkimaSpline.hpp
+++ b/include/Interpolation/AkimaSpline.hpp
@@ -4,11 +4,13 @@
 #include <cmath>
 #include <cstddef>
 #include <ranges>
+#include <span>
 #include <utility>
 #include <vector>
 
 #include <Interpolation/Concepts.hpp>
 #include <Interpolation/Samples.hpp>
+#include <Interpolation/Side.hpp>
 
 namespace Interpolation {
 
@@ -62,28 +64,55 @@ class AkimaSpline {
             return Scalar{};
         } else {
             const auto i = Detail::LocateSegment(_x, x);
-            const auto h = _x[i + 1] - _x[i];
-            const auto t = x - _x[i];
-
-            const auto two = static_cast<Scalar>(2);
-            const auto three = static_cast<Scalar>(3);
-            const auto c = (three * _m[i] - two * _s[i] - _s[i + 1]) / h;
-            const auto d = (_s[i] + _s[i + 1] - two * _m[i]) / (h * h);
-
-            if constexpr (N == 3) {
-                return static_cast<Scalar>(6) * d;
-            } else if constexpr (N == 2) {
-                return two * c + static_cast<Scalar>(6) * d * t;
-            } else if constexpr (N == 1) {
-                return _s[i] + t * (two * c + three * d * t);
-            } else {
-                return _y[i] + t * (_s[i] + t * (c + d * t));
-            }
+            return Piece<N>(i, x - _x[i]);
         }
     }
 
     /** @brief Evaluate the interpolant; the same as `Evaluate<0>`. */
     Scalar operator()(Real x) const { return Evaluate<0>(x); }
+
+    /**
+     * @brief Evaluate the interpolant, or its `N`th derivative, at every node.
+     *
+     * Writes one value per node into `out`, in node order, without a segment
+     * search: the segment adjoining each node is known.
+     *
+     * The third derivative jumps across an interior knot; `side` chooses which
+     * limit is reported, and defaults to the right-hand one, so that
+     * `EvaluateAtNodes<N>(out)` agrees with `Evaluate<N>(Node(k))` for every
+     * `k`. Lower orders agree from both sides to rounding.
+     *
+     * @tparam N Derivative order; `0` is the value itself.
+     * @param out Output, one per node. Overwritten.
+     * @param side Which adjoining segment to answer from at a node.
+     * @throws std::invalid_argument if `out` has the wrong length.
+     */
+    template <std::size_t N = 0>
+    void EvaluateAtNodes(std::span<Scalar> out, Side side = Side::Right) const {
+        const auto n = Size();
+        Detail::ValidateNodeOutput(out.size(), n, "AkimaSpline");
+        for (std::size_t k = 0; k < n; ++k) {
+            if constexpr (N > 3) {
+                out[k] = Scalar{};
+            } else {
+                const auto i = Detail::NodeSegment(n, k, side);
+                out[k] = Piece<N>(i, _x[k] - _x[i]);
+            }
+        }
+    }
+
+    /**
+     * @brief The nodal values or `N`th derivatives, in a fresh vector.
+     *
+     * The convenient form of EvaluateAtNodes. It allocates, so a caller
+     * sweeping many lines should keep one buffer and call EvaluateAtNodes.
+     */
+    template <std::size_t N = 0>
+    std::vector<Scalar> NodeValues(Side side = Side::Right) const {
+        std::vector<Scalar> values(Size());
+        EvaluateAtNodes<N>(std::span<Scalar>{values}, side);
+        return values;
+    }
 
     /** @brief Abscissa of node `i`. */
     Real Node(std::size_t i) const { return _x[i]; }
@@ -113,6 +142,28 @@ class AkimaSpline {
     YView _y;
     std::vector<Scalar> _m; // Secant slopes, one per segment.
     std::vector<Scalar> _s; // Akima-weighted slopes, one per node.
+
+    // Value or Nth derivative of the cubic on segment i, at offset t from its
+    // left node. The two quadratic and cubic coefficients follow from the end
+    // values and the Akima slopes, so they are recovered here rather than
+    // stored.
+    template <std::size_t N> Scalar Piece(std::size_t i, Real t) const {
+        const auto h = _x[i + 1] - _x[i];
+        const auto two = static_cast<Scalar>(2);
+        const auto three = static_cast<Scalar>(3);
+        const auto c = (three * _m[i] - two * _s[i] - _s[i + 1]) / h;
+        const auto d = (_s[i] + _s[i + 1] - two * _m[i]) / (h * h);
+
+        if constexpr (N == 3) {
+            return static_cast<Scalar>(6) * d;
+        } else if constexpr (N == 2) {
+            return two * c + static_cast<Scalar>(6) * d * t;
+        } else if constexpr (N == 1) {
+            return _s[i] + t * (two * c + three * d * t);
+        } else {
+            return _y[i] + t * (_s[i] + t * (c + d * t));
+        }
+    }
 
     void ComputeSlopes() {
         const auto n = Size();

--- a/include/Interpolation/BicubicSpline.hpp
+++ b/include/Interpolation/BicubicSpline.hpp
@@ -1,6 +1,7 @@
 #ifndef INTERPOLATION_BICUBIC_SPLINE_HPP
 #define INTERPOLATION_BICUBIC_SPLINE_HPP
 
+#include <algorithm>
 #include <cstddef>
 #include <ranges>
 #include <span>
@@ -9,7 +10,7 @@
 #include <vector>
 
 #include <Interpolation/Concepts.hpp>
-#include <Interpolation/CubicSpline.hpp>
+#include <Interpolation/CubicSplineSystem.hpp>
 #include <Interpolation/Grid.hpp>
 #include <Interpolation/Samples.hpp>
 
@@ -159,7 +160,7 @@ class BicubicSpline {
         _mxy.assign(_rows * _columns, Scalar{});
 
         // Copy the axes into contiguous buffers once: a view is not
-        // guaranteed to be contiguous, and the solver takes spans.
+        // guaranteed to be contiguous, and the systems below borrow theirs.
         std::vector<Real> xNodes(_rows);
         std::vector<Real> yNodes(_columns);
         for (std::size_t i = 0; i < _rows; ++i) {
@@ -169,55 +170,48 @@ class BicubicSpline {
             yNodes[j] = _y[j];
         }
 
+        // Every row shares one system and every column shares another, so the
+        // two matrices are assembled and factorised once for the whole grid
+        // rather than once per line. That is the tensor product paying for
+        // itself: the first-axis system is used _columns times for the values
+        // and again for the mixed term, and the second-axis system _rows
+        // times.
+        const auto xSystem =
+            CubicSplineSystem{std::span<const Real>{xNodes}, edge};
+        const auto ySystem =
+            CubicSplineSystem{std::span<const Real>{yNodes}, edge};
+
+        // The right-hand side is read while the solution is written, so the
+        // two cannot share a buffer. Both are allocated once for the whole
+        // grid rather than once per line.
         const auto longest = std::max(_rows, _columns);
         std::vector<Scalar> line(longest);
         std::vector<Scalar> result(longest);
-        std::vector<Real> sub(longest), diag(longest), super(longest);
-        std::vector<Scalar> slope(longest);
-
-        // One line solve, with whichever edge condition was asked for. The
-        // scratch buffers are allocated once for the whole grid rather than
-        // once per line.
-        const auto solveLine = [&](std::span<const Real> nodes,
-                                   std::size_t count) {
-            if (edge == BoundaryCondition::NotAKnot) {
-                Detail::NotAKnotCurvatures<Real, Scalar>(
-                    nodes, std::span<const Scalar>{line.data(), count},
-                    std::span<Scalar>{result.data(), count},
-                    std::span<Real>{sub.data(), count},
-                    std::span<Real>{diag.data(), count},
-                    std::span<Real>{super.data(), count},
-                    std::span<Scalar>{slope.data(), count});
-            } else {
-                Detail::NaturalCurvatures<Real, Scalar>(
-                    nodes, std::span<const Scalar>{line.data(), count},
-                    std::span<Scalar>{result.data(), count},
-                    std::span<Real>{sub.data(), count},
-                    std::span<Real>{diag.data(), count},
-                    std::span<Real>{super.data(), count});
-            }
-        };
 
         const auto solveAlongX = [&](auto read, auto write) {
+            const auto in = std::span<const Scalar>{line.data(), _rows};
+            const auto out = std::span<Scalar>{result.data(), _rows};
             for (std::size_t j = 0; j < _columns; ++j) {
                 for (std::size_t i = 0; i < _rows; ++i) {
                     line[i] = read(i, j);
                 }
-                solveLine(std::span<const Real>{xNodes}, _rows);
+                xSystem.Solve(in, out);
                 for (std::size_t i = 0; i < _rows; ++i) {
-                    write(i, j, result[i]);
+                    write(i, j, out[i]);
                 }
             }
         };
 
         const auto solveAlongY = [&](auto read, auto write) {
+            const auto in = std::span<const Scalar>{line.data(), _columns};
+            const auto out = std::span<Scalar>{result.data(), _columns};
             for (std::size_t i = 0; i < _rows; ++i) {
                 for (std::size_t j = 0; j < _columns; ++j) {
                     line[j] = read(i, j);
                 }
-                solveLine(std::span<const Real>{yNodes}, _columns);
+                ySystem.Solve(in, out);
                 for (std::size_t j = 0; j < _columns; ++j) {
-                    write(i, j, result[j]);
+                    write(i, j, out[j]);
                 }
             }
         };

--- a/include/Interpolation/CubicSpline.hpp
+++ b/include/Interpolation/CubicSpline.hpp
@@ -9,34 +9,23 @@
 #include <vector>
 
 #include <Interpolation/Concepts.hpp>
+#include <Interpolation/CubicSplineSystem.hpp>
 #include <Interpolation/Samples.hpp>
-#include <Interpolation/Tridiagonal.hpp>
+#include <Interpolation/Side.hpp>
 
 namespace Interpolation {
-
-/** @brief Endpoint conditions for CubicSpline. */
-enum class BoundaryCondition {
-    /** The endpoint second derivative is zero. */
-    Natural,
-    /** The endpoint first derivative is supplied by the caller. */
-    Clamped,
-    /**
-     * @brief The third derivative is continuous across the first and last
-     * interior knots.
-     *
-     * Imposes nothing false at the boundary, so a cubic is reproduced exactly
-     * and the scheme stays fourth order right up to the ends, where Natural
-     * costs an order. It is a condition on the whole system rather than on one
-     * endpoint, so it must be used at both ends and needs at least four nodes.
-     */
-    NotAKnot
-};
 
 /**
  * @brief Piecewise-cubic spline interpolation on ordered sample points.
  *
  * Construction takes ranges, borrowing lvalues and owning rvalues. Queries
  * outside the sample interval continue the first or final cubic piece.
+ *
+ * The linear system is assembled and factorised by CubicSplineSystem, which
+ * this class holds and exposes through System(). A caller fitting many
+ * ordinate sets on one grid should build that system once and solve into its
+ * own buffers rather than constructing a spline per dataset — the matrix
+ * depends on the nodes alone, so there is nothing to recompute.
  *
  * @tparam XView View over real abscissae.
  * @tparam YView View over real or complex ordinates.
@@ -50,6 +39,8 @@ class CubicSpline {
     using Real = std::ranges::range_value_t<XView>;
     /** @brief Ordinate type, real or complex. */
     using Scalar = std::ranges::range_value_t<YView>;
+    /** @brief The factorised system this spline was solved with. */
+    using System = CubicSplineSystem<XView>;
 
     /**
      * @brief Construct a spline with independently chosen endpoint conditions.
@@ -64,20 +55,11 @@ class CubicSpline {
      */
     CubicSpline(XView x, YView y, BoundaryCondition left, Scalar leftDerivative,
                 BoundaryCondition right, Scalar rightDerivative)
-        : _x{std::move(x)}, _y{std::move(y)} {
-        const auto notAKnot = left == BoundaryCondition::NotAKnot;
-        if (notAKnot != (right == BoundaryCondition::NotAKnot)) {
-            throw std::invalid_argument(
-                "CubicSpline: NotAKnot constrains the whole system rather "
-                "than one endpoint, so it must be used at both ends or "
-                "neither");
-        }
-        Detail::ValidateSamples(_x, _y, notAKnot ? 4 : 2, "CubicSpline");
-        if (notAKnot) {
-            SolveNotAKnot();
-        } else {
-            Solve(left, leftDerivative, right, rightDerivative);
-        }
+        : _system{Checked(std::move(x), y, left, right), left, right},
+          _y{std::move(y)} {
+        _ypp.assign(_system.Size(), Scalar{});
+        _system.Solve(_y, leftDerivative, rightDerivative,
+                      std::span<Scalar>{_ypp});
     }
 
     /** @brief Construct a natural spline, with Natural at both endpoints. */
@@ -96,9 +78,7 @@ class CubicSpline {
                       leftDerivative, both,         rightDerivative} {}
 
     /** @brief Number of interpolation nodes. */
-    std::size_t Size() const {
-        return static_cast<std::size_t>(std::ranges::size(_x));
-    }
+    std::size_t Size() const { return _system.Size(); }
 
     /**
      * @brief Evaluate the spline or its `N`th derivative.
@@ -110,20 +90,72 @@ class CubicSpline {
      * @param x Query abscissa.
      */
     template <std::size_t N = 0> Scalar Evaluate(Real x) const {
-        const auto i = Detail::LocateSegment(_x, x);
-        return Detail::SplinePiece<N, Real, Scalar>(_x[i + 1] - _x[i],
-                                                    x - _x[i], _y[i], _y[i + 1],
-                                                    _ypp[i], _ypp[i + 1]);
+        const auto i = Detail::LocateSegment(_system.Nodes(), x);
+        return Detail::SplinePiece<N, Real, Scalar>(
+            _system.Spacing(i), x - _system.Node(i), _y[i], _y[i + 1], _ypp[i],
+            _ypp[i + 1]);
     }
 
     /** @brief Evaluate the spline; the same as `Evaluate<0>`. */
     Scalar operator()(Real x) const { return Evaluate<0>(x); }
 
+    /**
+     * @brief Evaluate the spline, or its `N`th derivative, at every node.
+     *
+     * Writes one value per node into `out`, in node order, without a segment
+     * search: the segment adjoining each node is known. This is what a
+     * differentiation operator on a fixed grid wants, and it is where the
+     * general query path is doing work it need not.
+     *
+     * The third derivative jumps across an interior knot; `side` chooses which
+     * limit is reported, and defaults to the right-hand one, so that
+     * `EvaluateAtNodes<N>(out)` agrees with `Evaluate<N>(Node(k))` for every
+     * `k`. Lower orders agree from both sides to rounding.
+     *
+     * @tparam N Derivative order; `0` is the value itself.
+     * @param out Output, one per node. Overwritten.
+     * @param side Which adjoining segment to answer from at a node.
+     * @throws std::invalid_argument if `out` has the wrong length.
+     */
+    template <std::size_t N = 0>
+    void EvaluateAtNodes(std::span<Scalar> out, Side side = Side::Right) const {
+        _system.template EvaluateAtNodes<N>(_y, _ypp, out, side);
+    }
+
+    /**
+     * @brief The nodal values or `N`th derivatives, in a fresh vector.
+     *
+     * The convenient form of EvaluateAtNodes. It allocates, so a caller
+     * sweeping many lines should keep one buffer and call EvaluateAtNodes.
+     */
+    template <std::size_t N = 0>
+    std::vector<Scalar> NodeValues(Side side = Side::Right) const {
+        std::vector<Scalar> values(Size());
+        EvaluateAtNodes<N>(std::span<Scalar>{values}, side);
+        return values;
+    }
+
     /** @brief Abscissa of node `i`. */
-    Real Node(std::size_t i) const { return _x[i]; }
+    Real Node(std::size_t i) const { return _system.Node(i); }
 
     /** @brief Index of the segment used to evaluate `x`. */
-    std::size_t Segment(Real x) const { return Detail::LocateSegment(_x, x); }
+    std::size_t Segment(Real x) const {
+        return Detail::LocateSegment(_system.Nodes(), x);
+    }
+
+    /**
+     * @brief The factorised system behind this spline.
+     *
+     * Exposed so that a caller who built one spline and then finds it has more
+     * data on the same grid can reuse the factorisation rather than pay for it
+     * again.
+     */
+    const System &SplineSystem() const { return _system; }
+
+    /** @brief The nodal second derivatives. */
+    std::span<const Scalar> Curvatures() const {
+        return std::span<const Scalar>{_ypp};
+    }
 
     /**
      * @brief Integral of segment `i` from its left node over a width `t`.
@@ -143,7 +175,7 @@ class CubicSpline {
      * @f$ h(y_i + y_{i+1})/2 - h^3(M_i + M_{i+1})/24 @f$.
      */
     Scalar SegmentIntegral(std::size_t i, Real t) const {
-        const auto h = _x[i + 1] - _x[i];
+        const auto h = _system.Spacing(i);
         const auto u = t / h;
         const auto v = static_cast<Real>(1) - u;
         constexpr auto half = static_cast<Real>(1) / static_cast<Real>(2);
@@ -163,79 +195,24 @@ class CubicSpline {
     }
 
   private:
-    XView _x;
+    System _system;
     YView _y;
     std::vector<Scalar> _ypp; // Second derivatives at the nodes.
 
-    // Assemble and solve the tridiagonal system for the nodal second
-    // derivatives. The coefficients are real even when the ordinates are
-    // complex, so only the right-hand side carries the ordinate type. The
-    // right-hand side is built in _ypp, which the solve overwrites with the
-    // solution.
-    // Not-a-knot is solved in slope form and converted, for the reasons set
-    // out on Detail::NotAKnotCurvatures.
-    void SolveNotAKnot() {
-        const auto n = Size();
-        std::vector<Real> nodes(n);
-        std::vector<Scalar> values(n);
-        for (std::size_t i = 0; i < n; ++i) {
-            nodes[i] = _x[i];
-            values[i] = _y[i];
+    // Validate the sample pair before the system sees the abscissae on their
+    // own, so that a length mismatch and a bad grid are both reported against
+    // this class rather than against the system it delegates to.
+    static XView Checked(XView x, const YView &y, BoundaryCondition left,
+                         BoundaryCondition right) {
+        const auto notAKnot = left == BoundaryCondition::NotAKnot;
+        if (notAKnot != (right == BoundaryCondition::NotAKnot)) {
+            throw std::invalid_argument(
+                "CubicSpline: NotAKnot constrains the whole system rather "
+                "than one endpoint, so it must be used at both ends or "
+                "neither");
         }
-
-        _ypp.assign(n, Scalar{});
-        std::vector<Real> sub(n), diag(n), super(n);
-        std::vector<Scalar> slope(n);
-
-        Detail::NotAKnotCurvatures<Real, Scalar>(
-            std::span<const Real>{nodes}, std::span<const Scalar>{values},
-            std::span<Scalar>{_ypp}, std::span<Real>{sub},
-            std::span<Real>{diag}, std::span<Real>{super},
-            std::span<Scalar>{slope});
-    }
-
-    void Solve(BoundaryCondition left, Scalar leftDerivative,
-               BoundaryCondition right, Scalar rightDerivative) {
-        const auto n = Size();
-        constexpr auto oneThird = static_cast<Real>(1) / static_cast<Real>(3);
-        constexpr auto oneSixth = static_cast<Real>(1) / static_cast<Real>(6);
-
-        std::vector<Real> sub(n, 0), diag(n, 0), super(n, 0);
-        _ypp.assign(n, Scalar{});
-
-        // Interior rows express continuity of the first derivative.
-        for (std::size_t i = 1; i + 1 < n; ++i) {
-            const auto hPrev = _x[i] - _x[i - 1];
-            const auto hNext = _x[i + 1] - _x[i];
-            sub[i] = oneSixth * hPrev;
-            diag[i] = oneThird * (hPrev + hNext);
-            super[i] = oneSixth * hNext;
-            _ypp[i] = (_y[i + 1] - _y[i]) / hNext - (_y[i] - _y[i - 1]) / hPrev;
-        }
-
-        // A Natural condition states directly that the second derivative
-        // at that endpoint is zero.
-        if (left == BoundaryCondition::Natural) {
-            diag[0] = 1;
-        } else {
-            const auto h = _x[1] - _x[0];
-            diag[0] = oneThird * h;
-            super[0] = oneSixth * h;
-            _ypp[0] = (_y[1] - _y[0]) / h - leftDerivative;
-        }
-
-        if (right == BoundaryCondition::Natural) {
-            diag[n - 1] = 1;
-        } else {
-            const auto h = _x[n - 1] - _x[n - 2];
-            sub[n - 1] = oneSixth * h;
-            diag[n - 1] = oneThird * h;
-            _ypp[n - 1] = rightDerivative - (_y[n - 1] - _y[n - 2]) / h;
-        }
-
-        Detail::SolveTridiagonal<Real, Scalar>(
-            std::span<const Real>{sub}, std::span<Real>{diag},
-            std::span<const Real>{super}, std::span<Scalar>{_ypp});
+        Detail::ValidateSamples(x, y, notAKnot ? 4 : 2, "CubicSpline");
+        return x;
     }
 };
 

--- a/include/Interpolation/CubicSplineSystem.hpp
+++ b/include/Interpolation/CubicSplineSystem.hpp
@@ -1,0 +1,446 @@
+#ifndef INTERPOLATION_CUBIC_SPLINE_SYSTEM_HPP
+#define INTERPOLATION_CUBIC_SPLINE_SYSTEM_HPP
+
+#include <cstddef>
+#include <ranges>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <Interpolation/Concepts.hpp>
+#include <Interpolation/Samples.hpp>
+#include <Interpolation/Side.hpp>
+#include <Interpolation/Tridiagonal.hpp>
+
+namespace Interpolation {
+
+/** @brief Endpoint conditions for CubicSpline and CubicSplineSystem. */
+enum class BoundaryCondition {
+    /** The endpoint second derivative is zero. */
+    Natural,
+    /** The endpoint first derivative is supplied by the caller. */
+    Clamped,
+    /**
+     * @brief The third derivative is continuous across the first and last
+     * interior knots.
+     *
+     * Imposes nothing false at the boundary, so a cubic is reproduced exactly
+     * and the scheme stays fourth order right up to the ends, where Natural
+     * costs an order. It is a condition on the whole system rather than on one
+     * endpoint, so it must be used at both ends and needs at least four nodes.
+     */
+    NotAKnot
+};
+
+/**
+ * @brief The cubic-spline linear system for a fixed set of nodes, factorised
+ * once and reusable across any number of ordinate sets.
+ *
+ * A cubic spline is determined by a tridiagonal system whose **matrix depends
+ * on the nodes alone**; only the right-hand side carries the ordinates. So a
+ * caller holding many datasets on one grid — the components of a vector field,
+ * an ensemble of profiles, a field of spherical-harmonic coefficients sampled
+ * along a radial line — can factorise once and solve many times. That case is
+ * common enough to deserve a name, and naming it is what this class is for.
+ *
+ * It is also what CubicSpline is built on, so there is one assembly of the
+ * spline equations in the library rather than one per caller.
+ *
+ * @code
+ * const auto system = CubicSplineSystem{radii};       // factorised here
+ * std::vector<std::complex<double>> curvature(radii.size());
+ * for (const auto& line : coefficients) {
+ *     system.Solve(line, std::span{curvature});       // no allocation
+ *     // ... use the nodal second derivatives
+ * }
+ * @endcode
+ *
+ * Solve allocates nothing and is `const`, so a fixed system may be shared
+ * across threads. The matrix is real even when the ordinates are complex, so
+ * the ordinate type is a parameter of Solve rather than of the class: one
+ * system serves both.
+ *
+ * ### Which system
+ *
+ * Natural and Clamped are assembled in the **nodal-curvature** formulation and
+ * solved directly for what the evaluator wants.
+ *
+ * NotAKnot is assembled in the **nodal-slope** formulation and converted
+ * afterwards. Written directly in curvatures its boundary row reaches outside
+ * the tridiagonal band, and eliminating that entry produces a leading
+ * coefficient of `h0^2 - h1^2`, which vanishes on a uniform grid. In slopes the
+ * same condition gives the boundary row
+ *
+ * @f[
+ * h_1 d_0 + (h_0 + h_1) d_1 =
+ *   \frac{h_1 (2h_1 + 3h_0)\delta_0 + h_0^2 \delta_1}{h_0 + h_1},
+ * @f]
+ *
+ * whose diagonal is @f$h_1 > 0@f$ for any spacing. The conversion back to
+ * curvatures happens in place in the output, so it costs no scratch buffer.
+ *
+ * No pivoting is used. The interior rows are diagonally dominant by a factor
+ * of two; the two not-a-knot boundary rows are not, but the first elimination
+ * step turns the second pivot into @f$h_0 + h_1@f$, and the pivots stay
+ * positive.
+ *
+ * Construction takes a range of nodes, borrowing an lvalue and owning an
+ * rvalue, exactly as the interpolators do.
+ *
+ * @tparam XView View over the real abscissae.
+ */
+template <typename XView>
+    requires RealRange<XView> && std::ranges::view<XView>
+class CubicSplineSystem {
+  public:
+    /** @brief Abscissa precision. */
+    using Real = std::ranges::range_value_t<XView>;
+
+    /**
+     * @brief Assemble and factorise the system.
+     * @param x Strictly increasing abscissae; at least two, or four when
+     *        NotAKnot is used.
+     * @param left Condition at the first node.
+     * @param right Condition at the final node.
+     * @throws std::invalid_argument if the abscissae are not strictly
+     *         increasing, there are too few of them, or NotAKnot is asked for
+     *         at only one end.
+     */
+    CubicSplineSystem(XView x, BoundaryCondition left, BoundaryCondition right)
+        : _x{std::move(x)}, _left{left}, _right{right},
+          _notAKnot{left == BoundaryCondition::NotAKnot},
+          _factorization{Assemble(_x, left, right, _spacing)} {}
+
+    /** @brief Assemble with the natural condition at both ends. */
+    explicit CubicSplineSystem(XView x)
+        : CubicSplineSystem{std::move(x), BoundaryCondition::Natural,
+                            BoundaryCondition::Natural} {}
+
+    /** @brief Assemble with the same condition type at both ends. */
+    CubicSplineSystem(XView x, BoundaryCondition both)
+        : CubicSplineSystem{std::move(x), both, both} {}
+
+    /** @brief Number of nodes. */
+    std::size_t Size() const {
+        return static_cast<std::size_t>(std::ranges::size(_x));
+    }
+
+    /** @brief Abscissa of node `i`. */
+    Real Node(std::size_t i) const { return _x[i]; }
+
+    /** @brief The nodes themselves. */
+    const XView &Nodes() const { return _x; }
+
+    /** @brief Width of segment `i`, from node `i` to node `i + 1`. */
+    Real Spacing(std::size_t i) const { return _spacing[i]; }
+
+    /** @brief Condition imposed at the first node. */
+    BoundaryCondition LeftCondition() const { return _left; }
+
+    /** @brief Condition imposed at the final node. */
+    BoundaryCondition RightCondition() const { return _right; }
+
+    /**
+     * @brief Solve for the nodal second derivatives of one ordinate set.
+     *
+     * Neither endpoint may be Clamped, since no endpoint derivative is given;
+     * use the four-argument overload for that.
+     *
+     * @param y Ordinates, one per node.
+     * @param curvature Output, one per node. Overwritten.
+     * @throws std::invalid_argument if either length is wrong, or an endpoint
+     *         is Clamped.
+     */
+    template <typename YRange, typename Scalar>
+        requires InterpolationRanges<XView, YRange>
+    void Solve(const YRange &y, std::span<Scalar> curvature) const {
+        if (_left == BoundaryCondition::Clamped ||
+            _right == BoundaryCondition::Clamped) {
+            throw std::invalid_argument(
+                "CubicSplineSystem::Solve: a Clamped endpoint needs its "
+                "prescribed derivative, so use the overload that takes one");
+        }
+        Solve(y, Scalar{}, Scalar{}, curvature);
+    }
+
+    /**
+     * @brief Solve for the nodal second derivatives, giving the endpoint
+     * derivatives a Clamped condition needs.
+     *
+     * The derivatives are ignored at an endpoint whose condition is not
+     * Clamped, so a caller with a mixed pair need not care which is which.
+     *
+     * `y` and `curvature` must not overlap: the right-hand side is read as
+     * the solution is written.
+     *
+     * @param y Ordinates, one per node.
+     * @param leftDerivative First derivative at the first node.
+     * @param rightDerivative First derivative at the final node.
+     * @param curvature Output, one per node. Overwritten.
+     * @throws std::invalid_argument if either length is wrong.
+     */
+    template <typename YRange, typename Scalar>
+        requires InterpolationRanges<XView, YRange>
+    void Solve(const YRange &y, Scalar leftDerivative, Scalar rightDerivative,
+               std::span<Scalar> curvature) const {
+        const auto n = Size();
+        CheckLength(static_cast<std::size_t>(std::ranges::size(y)), n,
+                    "ordinate range");
+        CheckLength(curvature.size(), n, "curvature output");
+
+        if (_notAKnot) {
+            SolveNotAKnot(y, curvature);
+        } else {
+            SolveCurvatureForm(y, leftDerivative, rightDerivative, curvature);
+        }
+    }
+
+    /**
+     * @brief Index of the segment that owns node `k`, from a chosen side.
+     *
+     * `Side::Right` agrees with the segment an ordinary query at that node
+     * would select.
+     */
+    std::size_t NodeSegment(std::size_t k, Side side = Side::Right) const {
+        return Detail::NodeSegment(Size(), k, side);
+    }
+
+    /**
+     * @brief Evaluate a solved spline, or its `N`th derivative, at every node.
+     *
+     * The other half of what a differentiation operator wants. Given the
+     * ordinates and the curvatures Solve produced for them, this walks the
+     * segments once and writes the nodal values — where the general query path
+     * would pay a binary search per point to find segments it already knows.
+     *
+     * It takes the ordinates and curvatures rather than holding them, so a
+     * caller sweeping many datasets over one grid keeps its own buffers and
+     * this class stays a description of the grid.
+     *
+     * Values at a node agree from both sides, as do the first and second
+     * derivatives; the third jumps, and `side` chooses which limit is
+     * reported. The default is the right-hand one, matching the rest of the
+     * library. Orders above three are identically zero.
+     *
+     * @tparam N Derivative order; `0` is the value itself.
+     * @param y Ordinates, one per node.
+     * @param curvature Nodal second derivatives, as returned by Solve.
+     * @param out Output, one per node. Overwritten.
+     * @param side Which adjoining segment to answer from at a node.
+     * @throws std::invalid_argument if any length is wrong.
+     */
+    template <std::size_t N = 0, typename YRange, typename CRange,
+              typename Scalar>
+        requires InterpolationRanges<XView, YRange>
+    void EvaluateAtNodes(const YRange &y, const CRange &curvature,
+                         std::span<Scalar> out, Side side = Side::Right) const {
+        const auto n = Size();
+        CheckLength(static_cast<std::size_t>(std::ranges::size(y)), n,
+                    "ordinate range");
+        CheckLength(static_cast<std::size_t>(std::ranges::size(curvature)), n,
+                    "curvature range");
+        CheckLength(out.size(), n, "output range");
+
+        for (std::size_t k = 0; k < n; ++k) {
+            const auto i = Detail::NodeSegment(n, k, side);
+            out[k] = Detail::SplinePiece<N, Real, Scalar>(
+                _spacing[i], _x[k] - _x[i], y[i], y[i + 1], curvature[i],
+                curvature[i + 1]);
+        }
+    }
+
+    /**
+     * @brief Nodal second derivatives, returned in a fresh vector.
+     *
+     * The convenient form of Solve. It allocates, so the per-line inner loop
+     * of an operator should use Solve with its own buffer instead.
+     */
+    template <typename YRange>
+        requires InterpolationRanges<XView, YRange>
+    std::vector<std::ranges::range_value_t<YRange>>
+    Curvatures(const YRange &y) const {
+        std::vector<std::ranges::range_value_t<YRange>> curvature(Size());
+        Solve(y, std::span{curvature});
+        return curvature;
+    }
+
+  private:
+    XView _x;
+    BoundaryCondition _left;
+    BoundaryCondition _right;
+    bool _notAKnot;
+    std::vector<Real> _spacing; // Segment widths; filled by Assemble.
+    TridiagonalFactorization<Real> _factorization;
+
+    static void CheckLength(std::size_t given, std::size_t expected,
+                            const char *what) {
+        if (given != expected) {
+            throw std::invalid_argument(
+                std::string{"CubicSplineSystem::Solve: the "} + what +
+                " has length " + std::to_string(given) +
+                " but the system has " + std::to_string(expected) + " nodes");
+        }
+    }
+
+    // Build the three diagonals, factorise them, and leave the segment widths
+    // behind in `spacing`. Called from the member initialiser list, so it takes
+    // the pieces it fills rather than reading half-built members.
+    static TridiagonalFactorization<Real> Assemble(const XView &x,
+                                                   BoundaryCondition left,
+                                                   BoundaryCondition right,
+                                                   std::vector<Real> &spacing) {
+        const auto notAKnot = left == BoundaryCondition::NotAKnot;
+        if (notAKnot != (right == BoundaryCondition::NotAKnot)) {
+            throw std::invalid_argument(
+                "CubicSplineSystem: NotAKnot constrains the whole system "
+                "rather than one endpoint, so it must be used at both ends or "
+                "neither");
+        }
+        Detail::ValidateSamples(x, x, notAKnot ? 4 : 2, "CubicSplineSystem");
+
+        const auto n = static_cast<std::size_t>(std::ranges::size(x));
+        spacing.resize(n - 1);
+        for (std::size_t i = 0; i + 1 < n; ++i) {
+            spacing[i] = x[i + 1] - x[i];
+        }
+
+        std::vector<Real> sub(n, Real{}), diag(n, Real{}), super(n, Real{});
+        if (notAKnot) {
+            AssembleNotAKnot(spacing, sub, diag, super);
+        } else {
+            AssembleCurvatureForm(spacing, left, right, sub, diag, super);
+        }
+
+        return TridiagonalFactorization<Real>{std::span<const Real>{sub},
+                                              std::span<const Real>{diag},
+                                              std::span<const Real>{super}};
+    }
+
+    // Interior rows express continuity of the first derivative, written in
+    // nodal curvatures.
+    static void
+    AssembleCurvatureForm(const std::vector<Real> &h, BoundaryCondition left,
+                          BoundaryCondition right, std::vector<Real> &sub,
+                          std::vector<Real> &diag, std::vector<Real> &super) {
+        const auto n = diag.size();
+        constexpr auto oneThird = static_cast<Real>(1) / static_cast<Real>(3);
+        constexpr auto oneSixth = static_cast<Real>(1) / static_cast<Real>(6);
+
+        for (std::size_t i = 1; i + 1 < n; ++i) {
+            sub[i] = oneSixth * h[i - 1];
+            diag[i] = oneThird * (h[i - 1] + h[i]);
+            super[i] = oneSixth * h[i];
+        }
+
+        // A Natural condition states directly that the end curvature is zero.
+        if (left == BoundaryCondition::Natural) {
+            diag[0] = 1;
+        } else {
+            diag[0] = oneThird * h[0];
+            super[0] = oneSixth * h[0];
+        }
+
+        if (right == BoundaryCondition::Natural) {
+            diag[n - 1] = 1;
+        } else {
+            sub[n - 1] = oneSixth * h[n - 2];
+            diag[n - 1] = oneThird * h[n - 2];
+        }
+    }
+
+    // Interior rows express continuity of the second derivative, written in
+    // nodal slopes; the boundary rows are the not-a-knot condition.
+    static void AssembleNotAKnot(const std::vector<Real> &h,
+                                 std::vector<Real> &sub,
+                                 std::vector<Real> &diag,
+                                 std::vector<Real> &super) {
+        const auto n = diag.size();
+
+        for (std::size_t i = 1; i + 1 < n; ++i) {
+            sub[i] = h[i];
+            diag[i] = 2 * (h[i - 1] + h[i]);
+            super[i] = h[i - 1];
+        }
+
+        diag[0] = h[1];
+        super[0] = h[0] + h[1];
+
+        sub[n - 1] = h[n - 2] + h[n - 3];
+        diag[n - 1] = h[n - 3];
+    }
+
+    template <typename YRange, typename Scalar>
+    void SolveCurvatureForm(const YRange &y, Scalar leftDerivative,
+                            Scalar rightDerivative,
+                            std::span<Scalar> curvature) const {
+        const auto n = Size();
+        const auto &h = _spacing;
+
+        for (std::size_t i = 1; i + 1 < n; ++i) {
+            curvature[i] =
+                (y[i + 1] - y[i]) / h[i] - (y[i] - y[i - 1]) / h[i - 1];
+        }
+
+        curvature[0] = _left == BoundaryCondition::Natural
+                           ? Scalar{}
+                           : (y[1] - y[0]) / h[0] - leftDerivative;
+        curvature[n - 1] =
+            _right == BoundaryCondition::Natural
+                ? Scalar{}
+                : rightDerivative - (y[n - 1] - y[n - 2]) / h[n - 2];
+
+        _factorization.Solve(curvature);
+    }
+
+    template <typename YRange, typename Scalar>
+    void SolveNotAKnot(const YRange &y, std::span<Scalar> curvature) const {
+        const auto n = Size();
+        const auto &h = _spacing;
+        const auto secant = [&](std::size_t i) {
+            return (y[i + 1] - y[i]) / h[i];
+        };
+
+        // The right-hand side is built in the output and solved there, so the
+        // nodal slopes arrive in `curvature` before being converted.
+        for (std::size_t i = 1; i + 1 < n; ++i) {
+            curvature[i] = static_cast<Real>(3) *
+                           (h[i] * secant(i - 1) + h[i - 1] * secant(i));
+        }
+        curvature[0] = (h[1] * (2 * h[1] + 3 * h[0]) * secant(0) +
+                        h[0] * h[0] * secant(1)) /
+                       (h[0] + h[1]);
+        curvature[n - 1] =
+            (h[n - 3] * (2 * h[n - 3] + 3 * h[n - 2]) * secant(n - 2) +
+             h[n - 2] * h[n - 2] * secant(n - 3)) /
+            (h[n - 3] + h[n - 2]);
+
+        _factorization.Solve(curvature);
+
+        // Convert nodal slopes to nodal curvatures: on segment i the piece is
+        // y_i + d_i t + c t^2 + e t^3, so S''(x_i) = 2c. The conversion is done
+        // in place, which needs the final node computed first — it is the only
+        // one that reads a slope the forward sweep has already overwritten.
+        const auto last = (static_cast<Real>(2) * curvature[n - 2] +
+                           static_cast<Real>(4) * curvature[n - 1] -
+                           static_cast<Real>(6) * secant(n - 2)) /
+                          h[n - 2];
+        for (std::size_t i = 0; i + 1 < n; ++i) {
+            curvature[i] =
+                static_cast<Real>(2) *
+                (static_cast<Real>(3) * secant(i) -
+                 static_cast<Real>(2) * curvature[i] - curvature[i + 1]) /
+                h[i];
+        }
+        curvature[n - 1] = last;
+    }
+};
+
+/// Borrow an lvalue container of nodes and own an rvalue one.
+template <std::ranges::viewable_range X, typename... Rest>
+CubicSplineSystem(X &&, Rest...) -> CubicSplineSystem<std::views::all_t<X>>;
+
+} // namespace Interpolation
+
+#endif // INTERPOLATION_CUBIC_SPLINE_SYSTEM_HPP

--- a/include/Interpolation/Interpolation.hpp
+++ b/include/Interpolation/Interpolation.hpp
@@ -6,6 +6,7 @@
 #include <Interpolation/Bilinear.hpp>
 #include <Interpolation/Concepts.hpp>
 #include <Interpolation/CubicSpline.hpp>
+#include <Interpolation/CubicSplineSystem.hpp>
 #include <Interpolation/Function.hpp>
 #include <Interpolation/Grid.hpp>
 #include <Interpolation/Lagrange.hpp>
@@ -13,6 +14,7 @@
 #include <Interpolation/Piecewise.hpp>
 #include <Interpolation/Polynomial.hpp>
 #include <Interpolation/Samples.hpp>
+#include <Interpolation/Side.hpp>
 #include <Interpolation/Tridiagonal.hpp>
 
 #endif

--- a/include/Interpolation/Linear.hpp
+++ b/include/Interpolation/Linear.hpp
@@ -3,10 +3,13 @@
 
 #include <cstddef>
 #include <ranges>
+#include <span>
 #include <utility>
+#include <vector>
 
 #include <Interpolation/Concepts.hpp>
 #include <Interpolation/Samples.hpp>
+#include <Interpolation/Side.hpp>
 
 namespace Interpolation {
 
@@ -72,6 +75,48 @@ class Linear {
 
     /** @brief Evaluate the interpolant; the same as `Evaluate<0>`. */
     constexpr Scalar operator()(Real x) const { return Evaluate<0>(x); }
+
+    /**
+     * @brief Evaluate the interpolant, or its `N`th derivative, at every node.
+     *
+     * Writes one value per node into `out`, in node order, without a segment
+     * search: the segment adjoining each node is known. For a caller who wants
+     * the whole nodal sweep — a difference operator on a fixed grid, say —
+     * this replaces `Size()` binary searches with none.
+     *
+     * The first derivative jumps across an interior node, since the pieces are
+     * linear; `side` chooses which limit is reported, and defaults to the
+     * right-hand one, so that `EvaluateAtNodes<N>(out)` agrees with
+     * `Evaluate<N>(Node(k))` for every `k`.
+     *
+     * @tparam N Derivative order; `0` is the value itself.
+     * @param out Output, one per node. Overwritten.
+     * @param side Which adjoining segment to answer from at a node.
+     * @throws std::invalid_argument if `out` has the wrong length.
+     */
+    template <std::size_t N = 0>
+    void EvaluateAtNodes(std::span<Scalar> out, Side side = Side::Right) const {
+        const auto n = Size();
+        Detail::ValidateNodeOutput(out.size(), n, "Linear");
+        for (std::size_t k = 0; k < n; ++k) {
+            const auto i = Detail::NodeSegment(n, k, side);
+            out[k] = Detail::LinearPiece<N, Real, Scalar>(
+                _x[i + 1] - _x[i], _x[k] - _x[i], _y[i], _y[i + 1]);
+        }
+    }
+
+    /**
+     * @brief The nodal values or `N`th derivatives, in a fresh vector.
+     *
+     * The convenient form of EvaluateAtNodes. It allocates, so a caller
+     * sweeping many lines should keep one buffer and call EvaluateAtNodes.
+     */
+    template <std::size_t N = 0>
+    std::vector<Scalar> NodeValues(Side side = Side::Right) const {
+        std::vector<Scalar> values(Size());
+        EvaluateAtNodes<N>(std::span<Scalar>{values}, side);
+        return values;
+    }
 
     /** @brief Abscissa of node `i`. */
     constexpr Real Node(std::size_t i) const { return _x[i]; }

--- a/include/Interpolation/Piecewise.hpp
+++ b/include/Interpolation/Piecewise.hpp
@@ -11,16 +11,9 @@
 
 #include <Interpolation/Concepts.hpp>
 #include <Interpolation/Function.hpp>
+#include <Interpolation/Side.hpp>
 
 namespace Interpolation {
-
-/** @brief Which side of a breakpoint a query should be answered from. */
-enum class Side {
-    /** The piece ending at the breakpoint. */
-    Left,
-    /** The piece starting at the breakpoint. */
-    Right
-};
 
 /**
  * @brief A borrowed view of one piece, together with the interval it covers.

--- a/include/Interpolation/Samples.hpp
+++ b/include/Interpolation/Samples.hpp
@@ -2,15 +2,13 @@
 #define INTERPOLATION_SAMPLES_HPP
 
 #include <algorithm>
-#include <cassert>
 #include <cstddef>
 #include <ranges>
-#include <span>
 #include <stdexcept>
 #include <string>
 
 #include <Interpolation/Concepts.hpp>
-#include <Interpolation/Tridiagonal.hpp>
+#include <Interpolation/Side.hpp>
 
 namespace Interpolation::Detail {
 
@@ -102,6 +100,54 @@ LocateSegment(const XRange &x, Real query) {
 }
 
 /**
+ * @brief Check that a nodal output range is the right length.
+ *
+ * Shared by the `EvaluateAtNodes` of every interpolator, so the message is
+ * written once and reads the same wherever it comes from.
+ *
+ * @param given Length the caller supplied.
+ * @param expected Number of nodes.
+ * @param what Interpolator name, used in the exception message.
+ * @throws std::invalid_argument if the lengths differ.
+ */
+inline void
+ValidateNodeOutput(std::size_t given, std::size_t expected, const char *what) {
+    if (given != expected) {
+        throw std::invalid_argument(
+            std::string{what} +
+            "::EvaluateAtNodes: the output range has length " +
+            std::to_string(given) + " but there are " +
+            std::to_string(expected) + " nodes");
+    }
+}
+
+/**
+ * @brief Index of the segment that owns node `k`, from a chosen side.
+ *
+ * The counterpart of LocateSegment for a query that is known to land exactly
+ * on a node, so there is nothing to search for. `Side::Right` reproduces
+ * LocateSegment exactly, including its treatment of the final node, which has
+ * no segment to its right and so is answered from the one to its left;
+ * `Side::Left` mirrors it at the first node.
+ *
+ * The distinction matters only for a derivative order the interpolant does not
+ * carry across a knot — the third for a cubic, the first for a linear
+ * interpolant. Below that order the two sides agree to rounding.
+ *
+ * @param n Number of nodes, at least two.
+ * @param k Node index.
+ * @param side Which adjoining segment to use.
+ * @return Segment index in `[0, n - 1)`.
+ */
+constexpr std::size_t
+NodeSegment(std::size_t n, std::size_t k, Side side) {
+    if (side == Side::Right) {
+        return k + 1 < n ? k : n - 2;
+    }
+    return k > 0 ? k - 1 : 0;
+}
+
+/**
  * @brief Value or `N`th derivative of a linear piece.
  *
  * The piece spans `[0, h]` with end values `f0` and `f1`, evaluated at offset
@@ -152,159 +198,6 @@ SplinePiece(Real h, Real t, Scalar f0, Scalar f1, Scalar m0, Scalar m1) {
                        oneSixth;
         }
     }
-}
-
-/**
- * @brief Natural-spline second derivatives at the nodes.
- *
- * Solves the same tridiagonal system CubicSpline builds, with the natural
- * condition at both ends, for a sequence of values sampled on `nodes`. It is
- * factored out here because the tensor-product grid has to solve it once per
- * row and once per column, and the caller supplies the scratch diagonals so
- * that a whole grid costs one set of buffers rather than one per line.
- *
- * @param nodes Strictly increasing abscissae.
- * @param values Sampled values, the same length as `nodes`.
- * @param curvature Output, the same length as `nodes`.
- * @param sub Scratch, the same length as `nodes`.
- * @param diag Scratch, the same length as `nodes`.
- * @param super Scratch, the same length as `nodes`.
- */
-template <typename Real, typename Scalar>
-void
-NaturalCurvatures(std::span<const Real> nodes, std::span<const Scalar> values,
-                  std::span<Scalar> curvature, std::span<Real> sub,
-                  std::span<Real> diag, std::span<Real> super) {
-    const auto n = nodes.size();
-    assert(n >= 2);
-
-    constexpr auto oneThird = static_cast<Real>(1) / static_cast<Real>(3);
-    constexpr auto oneSixth = static_cast<Real>(1) / static_cast<Real>(6);
-
-    std::ranges::fill(sub, Real{});
-    std::ranges::fill(diag, Real{});
-    std::ranges::fill(super, Real{});
-    std::ranges::fill(curvature, Scalar{});
-
-    for (std::size_t i = 1; i + 1 < n; ++i) {
-        const auto hPrev = nodes[i] - nodes[i - 1];
-        const auto hNext = nodes[i + 1] - nodes[i];
-        sub[i] = oneSixth * hPrev;
-        diag[i] = oneThird * (hPrev + hNext);
-        super[i] = oneSixth * hNext;
-        curvature[i] = (values[i + 1] - values[i]) / hNext -
-                       (values[i] - values[i - 1]) / hPrev;
-    }
-
-    // The natural condition states directly that the end curvature is zero.
-    diag[0] = 1;
-    diag[n - 1] = 1;
-
-    SolveTridiagonal<Real, Scalar>(std::span<const Real>{sub}, diag,
-                                   std::span<const Real>{super}, curvature);
-}
-
-/**
- * @brief Not-a-knot second derivatives at the nodes.
- *
- * The not-a-knot condition makes the third derivative continuous across the
- * first and last interior knots, so the first two polynomial pieces are one
- * cubic and the last two are another. Unlike the natural condition it does
- * not impose anything false at the boundary, so the scheme stays fourth
- * order there and a cubic is reproduced exactly.
- *
- * It is solved in the nodal-slope formulation rather than the nodal-curvature
- * one. Written directly in curvatures the boundary row reaches outside the
- * tridiagonal band, and eliminating that entry produces a leading coefficient
- * of `h0^2 - h1^2`, which vanishes on a uniform grid. In slopes the same
- * condition gives the boundary row
- *
- * @f[
- * h_1 d_0 + (h_0 + h_1) d_1 =
- *   \frac{h_1 (2h_1 + 3h_0)\delta_0 + h_0^2 \delta_1}{h_0 + h_1},
- * @f]
- *
- * whose diagonal is @f$h_1 > 0@f$ for any spacing. The slopes are then
- * converted to curvatures so that evaluation uses the same segment formula as
- * every other spline here.
- *
- * No pivoting is used. The interior rows are diagonally dominant by a factor
- * of two; the two boundary rows are not, but the first elimination step turns
- * the second pivot into @f$h_0 + h_1@f$, and the pivots stay positive.
- *
- * @param nodes Strictly increasing abscissae, at least four of them.
- * @param values Sampled values, the same length as `nodes`.
- * @param curvature Output, the same length as `nodes`.
- * @param sub Scratch, the same length as `nodes`.
- * @param diag Scratch, the same length as `nodes`.
- * @param super Scratch, the same length as `nodes`.
- * @param slope Scratch, the same length as `nodes`.
- */
-template <typename Real, typename Scalar>
-void
-NotAKnotCurvatures(std::span<const Real> nodes, std::span<const Scalar> values,
-                   std::span<Scalar> curvature, std::span<Real> sub,
-                   std::span<Real> diag, std::span<Real> super,
-                   std::span<Scalar> slope) {
-    const auto n = nodes.size();
-    assert(n >= 4);
-
-    const auto h = [&](std::size_t i) { return nodes[i + 1] - nodes[i]; };
-    const auto secant = [&](std::size_t i) {
-        return (values[i + 1] - values[i]) / h(i);
-    };
-
-    std::ranges::fill(sub, Real{});
-    std::ranges::fill(diag, Real{});
-    std::ranges::fill(super, Real{});
-    std::ranges::fill(slope, Scalar{});
-
-    // Interior rows: continuity of the second derivative, in slope form.
-    for (std::size_t i = 1; i + 1 < n; ++i) {
-        sub[i] = h(i);
-        diag[i] = 2 * (h(i - 1) + h(i));
-        super[i] = h(i - 1);
-        slope[i] = static_cast<Real>(3) *
-                   (h(i) * secant(i - 1) + h(i - 1) * secant(i));
-    }
-
-    // Left not-a-knot row.
-    {
-        const auto h0 = h(0);
-        const auto h1 = h(1);
-        diag[0] = h1;
-        super[0] = h0 + h1;
-        slope[0] = (h1 * (2 * h1 + 3 * h0) * secant(0) + h0 * h0 * secant(1)) /
-                   (h0 + h1);
-    }
-
-    // Right not-a-knot row, the mirror of the left.
-    {
-        const auto hLast = h(n - 2);
-        const auto hPrev = h(n - 3);
-        sub[n - 1] = hLast + hPrev;
-        diag[n - 1] = hPrev;
-        slope[n - 1] = (hPrev * (2 * hPrev + 3 * hLast) * secant(n - 2) +
-                        hLast * hLast * secant(n - 3)) /
-                       (hPrev + hLast);
-    }
-
-    SolveTridiagonal<Real, Scalar>(std::span<const Real>{sub}, diag,
-                                   std::span<const Real>{super}, slope);
-
-    // Convert nodal slopes to nodal curvatures: on segment i the piece is
-    // y_i + d_i t + c t^2 + e t^3, so S''(x_i) = 2c.
-    for (std::size_t i = 0; i + 1 < n; ++i) {
-        curvature[i] = static_cast<Real>(2) *
-                       (static_cast<Real>(3) * secant(i) -
-                        static_cast<Real>(2) * slope[i] - slope[i + 1]) /
-                       h(i);
-    }
-    const auto hEnd = h(n - 2);
-    curvature[n - 1] = (static_cast<Real>(2) * slope[n - 2] +
-                        static_cast<Real>(4) * slope[n - 1] -
-                        static_cast<Real>(6) * secant(n - 2)) /
-                       hEnd;
 }
 
 } // namespace Interpolation::Detail

--- a/include/Interpolation/Side.hpp
+++ b/include/Interpolation/Side.hpp
@@ -1,0 +1,30 @@
+#ifndef INTERPOLATION_SIDE_HPP
+#define INTERPOLATION_SIDE_HPP
+
+namespace Interpolation {
+
+/**
+ * @brief Which side of a breakpoint or node a query should be answered from.
+ *
+ * The library is right-continuous by default: a piece owns the half-open
+ * interval `[lower, upper)`, so a query landing exactly on a breakpoint is
+ * answered from the piece starting there. `Side` is how a caller asks for the
+ * other limit.
+ *
+ * It lives in its own header because the convention is shared. `Piecewise`
+ * uses it across breakpoints, where a genuine discontinuity may sit; the
+ * one-dimensional interpolators use it at their own nodes, where the value
+ * agrees from both sides but a high enough derivative need not — the third
+ * derivative of a cubic spline and the first of a piecewise-linear
+ * interpolant both jump there.
+ */
+enum class Side {
+    /** The piece ending at the breakpoint. */
+    Left,
+    /** The piece starting at the breakpoint. */
+    Right
+};
+
+} // namespace Interpolation
+
+#endif // INTERPOLATION_SIDE_HPP

--- a/include/Interpolation/Tridiagonal.hpp
+++ b/include/Interpolation/Tridiagonal.hpp
@@ -1,11 +1,15 @@
 #ifndef INTERPOLATION_TRIDIAGONAL_HPP
 #define INTERPOLATION_TRIDIAGONAL_HPP
 
-#include <cassert>
 #include <cstddef>
 #include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
-namespace Interpolation::Detail {
+#include <Interpolation/Concepts.hpp>
+
+namespace Interpolation {
 
 /**
  * @brief Solve a tridiagonal system in place by the Thomas algorithm.
@@ -25,19 +29,29 @@ namespace Interpolation::Detail {
  * `(h[i - 1] + h[i]) / 3`, and every boundary row is dominant by the same
  * factor of two.
  *
+ * This is the one-shot form: `diag` is consumed by the elimination, so nothing
+ * survives that a second right-hand side could reuse. For many right-hand
+ * sides on one matrix use TridiagonalFactorization, which keeps the pivots.
+ *
  * @param sub Sub-diagonal, length `n`.
  * @param diag Diagonal, length `n`. Overwritten.
  * @param super Super-diagonal, length `n`.
  * @param rhs Right-hand side, length `n`. Overwritten with the solution.
- * @pre All four spans have the same non-zero length.
+ * @throws std::invalid_argument if the spans are empty or differ in length.
  */
 template <typename Real, typename Scalar>
 void
 SolveTridiagonal(std::span<const Real> sub, std::span<Real> diag,
                  std::span<const Real> super, std::span<Scalar> rhs) {
     const auto n = diag.size();
-    assert(n > 0);
-    assert(sub.size() == n && super.size() == n && rhs.size() == n);
+    if (n == 0) {
+        throw std::invalid_argument("SolveTridiagonal: the system is empty");
+    }
+    if (sub.size() != n || super.size() != n || rhs.size() != n) {
+        throw std::invalid_argument(
+            "SolveTridiagonal: the diagonals and the right-hand side must all "
+            "have the same length");
+    }
 
     // Forward elimination.
     for (std::size_t i = 1; i < n; ++i) {
@@ -53,6 +67,144 @@ SolveTridiagonal(std::span<const Real> sub, std::span<Real> diag,
     }
 }
 
-} // namespace Interpolation::Detail
+/**
+ * @brief A tridiagonal matrix reduced once, ready to act on many right-hand
+ * sides.
+ *
+ * The elimination in SolveTridiagonal destroys the diagonal it works on, so
+ * solving `k` right-hand sides on one matrix costs `k` eliminations. That is
+ * the right trade when the matrix is built for a single solve, and the wrong
+ * one whenever a matrix outlives its right-hand side — a spline system on a
+ * fixed grid applied to many datasets, a tensor-product grid applied line by
+ * line, an operator applied every iteration of a matrix-free solve.
+ *
+ * This class does the elimination once at construction and keeps what it
+ * produces. Each Solve is then a forward sweep and a back substitution, and
+ * because the reciprocals of the pivots are stored rather than the pivots
+ * themselves, it performs no division at all.
+ *
+ * The matrix is real and the right-hand side may be real or complex, so
+ * `Scalar` is a parameter of Solve rather than of the class: one factorisation
+ * serves both.
+ *
+ * @code
+ * const auto factorization =
+ *     TridiagonalFactorization<double>{sub, diag, super};
+ * for (auto& line : lines) {
+ *     factorization.Solve(std::span{line});  // in place
+ * }
+ * @endcode
+ *
+ * No pivoting is performed, for the reason given on SolveTridiagonal. A zero
+ * pivot is reported at construction rather than left to produce infinities
+ * during a solve.
+ *
+ * @tparam R Real precision of the matrix entries.
+ */
+template <typename R>
+    requires Real<R>
+class TridiagonalFactorization {
+  public:
+    /** @brief Precision of the matrix entries. */
+    using Real = R;
+
+    /**
+     * @brief Reduce a tridiagonal matrix.
+     *
+     * The diagonals are indexed against the full matrix, exactly as in
+     * SolveTridiagonal: `sub[0]` and `super[n - 1]` are not read.
+     *
+     * @param sub Sub-diagonal, length `n`.
+     * @param diag Diagonal, length `n`.
+     * @param super Super-diagonal, length `n`.
+     * @throws std::invalid_argument if the spans are empty, differ in length,
+     *         or the elimination meets a zero pivot.
+     */
+    TridiagonalFactorization(std::span<const R> sub, std::span<const R> diag,
+                             std::span<const R> super) {
+        const auto n = diag.size();
+        if (n == 0) {
+            throw std::invalid_argument(
+                "TridiagonalFactorization: the system is empty");
+        }
+        if (sub.size() != n || super.size() != n) {
+            throw std::invalid_argument("TridiagonalFactorization: the three "
+                                        "diagonals must have the same length");
+        }
+
+        _multiplier.assign(n, R{});
+        _inversePivot.assign(n, R{});
+        _superOverPivot.assign(n, R{});
+
+        auto pivot = diag[0];
+        CheckPivot(pivot, 0);
+        _inversePivot[0] = R{1} / pivot;
+
+        for (std::size_t i = 1; i < n; ++i) {
+            // The multiplier is the entry the elimination would have written
+            // into L; keeping it is what lets a later right-hand side skip
+            // the elimination entirely.
+            _multiplier[i] = sub[i] * _inversePivot[i - 1];
+            pivot = diag[i] - _multiplier[i] * super[i - 1];
+            CheckPivot(pivot, i);
+            _inversePivot[i] = R{1} / pivot;
+            _superOverPivot[i - 1] = super[i - 1] * _inversePivot[i - 1];
+        }
+    }
+
+    /** @brief Order of the system. */
+    std::size_t Size() const { return _inversePivot.size(); }
+
+    /**
+     * @brief Solve for one right-hand side, in place.
+     *
+     * @tparam Scalar Right-hand side type, real or complex.
+     * @param rhs Right-hand side, length `Size()`. Overwritten with the
+     *        solution.
+     * @throws std::invalid_argument if `rhs` has the wrong length.
+     */
+    template <typename Scalar> void Solve(std::span<Scalar> rhs) const {
+        const auto n = Size();
+        if (rhs.size() != n) {
+            throw std::invalid_argument(
+                "TridiagonalFactorization::Solve: the right-hand side has "
+                "length " +
+                std::to_string(rhs.size()) + " but the system has order " +
+                std::to_string(n));
+        }
+
+        for (std::size_t i = 1; i < n; ++i) {
+            rhs[i] -= _multiplier[i] * rhs[i - 1];
+        }
+
+        rhs[n - 1] *= _inversePivot[n - 1];
+        for (std::size_t i = n - 1; i-- > 0;) {
+            rhs[i] =
+                rhs[i] * _inversePivot[i] - _superOverPivot[i] * rhs[i + 1];
+        }
+    }
+
+  private:
+    std::vector<R> _multiplier;     // sub[i] / pivot[i - 1]; [0] unused.
+    std::vector<R> _inversePivot;   // 1 / pivot[i].
+    std::vector<R> _superOverPivot; // super[i] / pivot[i]; [n - 1] unused.
+
+    static void CheckPivot(R pivot, std::size_t row) {
+        if (pivot == R{}) {
+            throw std::invalid_argument(
+                "TridiagonalFactorization: the elimination met a zero pivot "
+                "at row " +
+                std::to_string(row) +
+                "; the matrix is singular or needs pivoting");
+        }
+    }
+};
+
+/// Deduce the precision from the diagonals.
+template <typename R>
+TridiagonalFactorization(std::span<const R>, std::span<const R>,
+                         std::span<const R>) -> TridiagonalFactorization<R>;
+
+} // namespace Interpolation
 
 #endif // INTERPOLATION_TRIDIAGONAL_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,8 @@ add_executable(Tests
                TestFunctionAlgebra.cpp
                TestGrid2D.cpp
                TestPiecewise.cpp
+               TestSplineSystem.cpp
+               TestAtNodes.cpp
                AllocationCounter.cpp)
 
 target_link_libraries(Tests PRIVATE Interpolation::Interpolation gtest_main)

--- a/tests/TestAtNodes.cpp
+++ b/tests/TestAtNodes.cpp
@@ -1,0 +1,297 @@
+#include <gtest/gtest.h>
+
+#include <Interpolation/Interpolation.hpp>
+#include <cmath>
+#include <complex>
+#include <random>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include "AllocationCounter.hpp"
+#include "TestUtilities.h"
+
+// Evaluating at every node is what a differentiation operator on a fixed grid
+// actually asks for, and it is the one query that needs no search: the segment
+// adjoining each node is known. These checks pin the path to the general one
+// it shortcuts, so the two cannot drift apart.
+
+namespace {
+
+using Interpolation::AkimaSpline;
+using Interpolation::BoundaryCondition;
+using Interpolation::CubicSpline;
+using Interpolation::CubicSplineSystem;
+using Interpolation::Linear;
+using Interpolation::Side;
+
+// Uneven spacing throughout, so nothing here can pass by accident on a
+// uniform grid.
+const std::vector<double> kNodes{0.0, 0.4, 1.5, 1.7, 2.9, 4.4, 4.6, 6.0};
+
+std::vector<double>
+SampledOn(const std::vector<double> &x) {
+    std::vector<double> y;
+    y.reserve(x.size());
+    for (const auto value : x) {
+        y.push_back(std::exp(-0.3 * value) * std::sin(1.7 * value));
+    }
+    return y;
+}
+
+// Somewhere strictly inside segment i, where a piecewise-constant derivative
+// takes its value for that segment.
+double
+Inside(std::size_t i) {
+    return 0.5 * (kNodes[i] + kNodes[i + 1]);
+}
+
+// The nodal sweep must agree with the general query at every node, for every
+// derivative order the interpolant carries.
+template <std::size_t N, typename Interpolant>
+void
+CheckOrderAgrees(const Interpolant &f) {
+    SCOPED_TRACE("derivative order " + std::to_string(N));
+    const auto n = f.Size();
+
+    std::vector<typename Interpolant::Scalar> swept(n);
+    f.template EvaluateAtNodes<N>(
+        std::span<typename Interpolant::Scalar>{swept});
+
+    for (std::size_t k = 0; k < n; ++k) {
+        SCOPED_TRACE("node " + std::to_string(k));
+        // Bit-for-bit. The two paths run the same segment formula on the same
+        // segment; anything less would mean one of them had grown its own.
+        EXPECT_EQ(swept[k], f.template Evaluate<N>(f.Node(k)));
+    }
+
+    const auto returned = f.template NodeValues<N>();
+    ASSERT_EQ(returned.size(), n);
+    for (std::size_t k = 0; k < n; ++k) {
+        EXPECT_EQ(returned[k], swept[k]);
+    }
+}
+
+} // namespace
+
+TEST(EvaluateAtNodes, AgreesWithTheGeneralQueryForEveryInterpolant) {
+    const auto y = SampledOn(kNodes);
+
+    {
+        const Linear f{kNodes, y};
+        CheckOrderAgrees<0>(f);
+        CheckOrderAgrees<1>(f);
+        CheckOrderAgrees<2>(f);
+    }
+    {
+        const CubicSpline f{kNodes, y};
+        CheckOrderAgrees<0>(f);
+        CheckOrderAgrees<1>(f);
+        CheckOrderAgrees<2>(f);
+        CheckOrderAgrees<3>(f);
+        CheckOrderAgrees<4>(f);
+    }
+    {
+        const CubicSpline f{kNodes, y, BoundaryCondition::NotAKnot, 0.0, 0.0};
+        CheckOrderAgrees<0>(f);
+        CheckOrderAgrees<1>(f);
+        CheckOrderAgrees<2>(f);
+        CheckOrderAgrees<3>(f);
+    }
+    {
+        const AkimaSpline f{kNodes, y};
+        CheckOrderAgrees<0>(f);
+        CheckOrderAgrees<1>(f);
+        CheckOrderAgrees<2>(f);
+        CheckOrderAgrees<3>(f);
+        CheckOrderAgrees<4>(f);
+    }
+}
+
+TEST(EvaluateAtNodes, ReproducesTheOrdinatesExactly) {
+    const auto y = SampledOn(kNodes);
+    const CubicSpline spline{kNodes, y};
+    const AkimaSpline akima{kNodes, y};
+    const Linear linear{kNodes, y};
+
+    // The interpolation property, read straight off the nodal sweep.
+    for (const auto &values :
+         {spline.NodeValues(), akima.NodeValues(), linear.NodeValues()}) {
+        ASSERT_EQ(values.size(), y.size());
+        for (std::size_t k = 0; k < y.size(); ++k) {
+            EXPECT_NEAR(values[k], y[k], 1.0e-13);
+        }
+    }
+}
+
+TEST(EvaluateAtNodes, TheTwoSidesAgreeBelowTheDiscontinuousOrder) {
+    const auto y = SampledOn(kNodes);
+    const CubicSpline spline{kNodes, y};
+
+    for (std::size_t order = 0; order < 3; ++order) {
+        std::vector<double> right(kNodes.size()), left(kNodes.size());
+        const auto sweep = [&](Side side, std::vector<double> &out) {
+            switch (order) {
+            case 0:
+                spline.EvaluateAtNodes<0>(std::span<double>{out}, side);
+                break;
+            case 1:
+                spline.EvaluateAtNodes<1>(std::span<double>{out}, side);
+                break;
+            default:
+                spline.EvaluateAtNodes<2>(std::span<double>{out}, side);
+                break;
+            }
+        };
+        sweep(Side::Right, right);
+        sweep(Side::Left, left);
+
+        for (std::size_t k = 0; k < kNodes.size(); ++k) {
+            SCOPED_TRACE("order " + std::to_string(order) + ", node " +
+                         std::to_string(k));
+            // A cubic spline is C2, so only rounding separates the two limits
+            // up to the second derivative.
+            EXPECT_NEAR(left[k], right[k], 1.0e-12);
+        }
+    }
+}
+
+TEST(EvaluateAtNodes, TheSidesStraddleTheJumpInTheThirdDerivative) {
+    const auto y = SampledOn(kNodes);
+    const CubicSpline spline{kNodes, y};
+    const auto n = kNodes.size();
+
+    const auto right = spline.NodeValues<3>(Side::Right);
+    const auto left = spline.NodeValues<3>(Side::Left);
+
+    // The third derivative is constant on each segment, so its value anywhere
+    // inside a segment is exactly the one-sided limit at either end. That is
+    // what makes this an equality rather than a limit.
+    for (std::size_t k = 0; k < n; ++k) {
+        SCOPED_TRACE("node " + std::to_string(k));
+        const auto rightSegment = k + 1 < n ? k : n - 2;
+        const auto leftSegment = k > 0 ? k - 1 : 0;
+        EXPECT_EQ(right[k], spline.Evaluate<3>(Inside(rightSegment)));
+        EXPECT_EQ(left[k], spline.Evaluate<3>(Inside(leftSegment)));
+    }
+
+    // And they really do differ, so the choice of side is not cosmetic.
+    bool anyJump = false;
+    for (std::size_t k = 1; k + 1 < n; ++k) {
+        anyJump = anyJump || left[k] != right[k];
+    }
+    EXPECT_TRUE(anyJump)
+        << "the third derivative was continuous at every knot, so this test "
+           "is not exercising the sided path";
+}
+
+TEST(EvaluateAtNodes, TheFirstDerivativeOfALinearInterpolantIsSided) {
+    const auto y = SampledOn(kNodes);
+    const Linear f{kNodes, y};
+    const auto n = kNodes.size();
+
+    const auto right = f.NodeValues<1>(Side::Right);
+    const auto left = f.NodeValues<1>(Side::Left);
+
+    for (std::size_t k = 0; k < n; ++k) {
+        SCOPED_TRACE("node " + std::to_string(k));
+        const auto rightSegment = k + 1 < n ? k : n - 2;
+        const auto leftSegment = k > 0 ? k - 1 : 0;
+        EXPECT_EQ(right[k], f.Evaluate<1>(Inside(rightSegment)));
+        EXPECT_EQ(left[k], f.Evaluate<1>(Inside(leftSegment)));
+    }
+    EXPECT_NE(left[1], right[1]);
+}
+
+TEST(EvaluateAtNodes, WorksForComplexOrdinates) {
+    using C = std::complex<double>;
+    std::vector<C> y;
+    y.reserve(kNodes.size());
+    for (const auto value : kNodes) {
+        y.emplace_back(std::cos(1.1 * value), std::sin(0.7 * value));
+    }
+
+    const CubicSpline spline{kNodes, y};
+    const auto values = spline.NodeValues<1>();
+    for (std::size_t k = 0; k < kNodes.size(); ++k) {
+        EXPECT_EQ(values[k], spline.Evaluate<1>(kNodes[k]));
+    }
+}
+
+TEST(EvaluateAtNodes, RejectsAnOutputOfTheWrongLength) {
+    const auto y = SampledOn(kNodes);
+    std::vector<double> tooShort(kNodes.size() - 1);
+
+    const Linear linear{kNodes, y};
+    const CubicSpline spline{kNodes, y};
+    const AkimaSpline akima{kNodes, y};
+
+    EXPECT_THROW(linear.EvaluateAtNodes(std::span<double>{tooShort}),
+                 std::invalid_argument);
+    EXPECT_THROW(spline.EvaluateAtNodes(std::span<double>{tooShort}),
+                 std::invalid_argument);
+    EXPECT_THROW(akima.EvaluateAtNodes(std::span<double>{tooShort}),
+                 std::invalid_argument);
+}
+
+TEST(EvaluateAtNodes, TheSweepAllocatesNothing) {
+    if constexpr (!InterpolationTest::AllocationCountingEnabled()) {
+        GTEST_SKIP() << "allocation counting stands down under sanitizers";
+    } else {
+        {
+            const auto before = InterpolationTest::AllocationCount();
+            void *probe = ::operator new(64);
+            ::operator delete(probe);
+            ASSERT_GT(InterpolationTest::AllocationCount(), before)
+                << "the allocation counter is not observing allocations";
+        }
+
+        const auto y = SampledOn(kNodes);
+        const CubicSpline spline{kNodes, y};
+        const AkimaSpline akima{kNodes, y};
+        const Linear linear{kNodes, y};
+        std::vector<double> out(kNodes.size());
+
+        const auto before = InterpolationTest::AllocationCount();
+        for (int i = 0; i < 100; ++i) {
+            spline.EvaluateAtNodes<1>(std::span<double>{out});
+            akima.EvaluateAtNodes<1>(std::span<double>{out});
+            linear.EvaluateAtNodes<0>(std::span<double>{out});
+        }
+        const auto after = InterpolationTest::AllocationCount();
+
+        EXPECT_EQ(after, before)
+            << "the nodal sweep allocated " << (after - before) << " times";
+    }
+}
+
+TEST(EvaluateAtNodes, TheOperatorShapeReproducesASplinePerLine) {
+    // The whole point, end to end: one factorisation and one pair of buffers,
+    // swept over many datasets on a shared grid, must give exactly what
+    // building a spline per dataset gives.
+    const auto seed = InterpolationTest::ReportedSeed(20260823);
+    const auto n = kNodes.size();
+    const CubicSplineSystem system{kNodes, BoundaryCondition::NotAKnot};
+
+    std::vector<double> curvature(n), derivative(n);
+    std::mt19937_64 engine{seed};
+    std::uniform_real_distribution<double> value{-2.0, 2.0};
+
+    for (int line = 0; line < 32; ++line) {
+        std::vector<double> y(n);
+        for (auto &entry : y) {
+            entry = value(engine);
+        }
+
+        system.Solve(y, std::span<double>{curvature});
+        system.EvaluateAtNodes<1>(y, curvature, std::span<double>{derivative});
+
+        const CubicSpline reference{kNodes, y, BoundaryCondition::NotAKnot, 0.0,
+                                    0.0};
+        for (std::size_t k = 0; k < n; ++k) {
+            SCOPED_TRACE("line " + std::to_string(line) + ", node " +
+                         std::to_string(k));
+            EXPECT_EQ(derivative[k], reference.Evaluate<1>(kNodes[k]));
+        }
+    }
+}

--- a/tests/TestPiecewise.cpp
+++ b/tests/TestPiecewise.cpp
@@ -320,3 +320,126 @@ TEST(CubicSpline, NotAKnotMustBeUsedAtBothEnds) {
                      Interpolation::BoundaryCondition::NotAKnot, 0.0}),
                  std::invalid_argument);
 }
+
+// --- The conventions a consumer depends on ----------------------------------
+//
+// GSHTrans has adopted this class's breakpoint semantics wholesale: its
+// RadialGrid carries an element partition represented as breakpoints in
+// exactly this sense, so that the two libraries cannot disagree about what
+// happens at a core-mantle boundary. The tests above exercise the class; these
+// state the contract, so that a change to it fails here and is noticed rather
+// than discovered downstream.
+
+namespace {
+
+using Contract =
+    Interpolation::Linear<std::ranges::ref_view<const std::vector<double>>,
+                          std::ranges::ref_view<const std::vector<double>>>;
+
+// Two pieces meeting at 1.0 with different values there: a genuine jump, of
+// the kind a material discontinuity produces.
+const std::vector<double> kLowerX{0.0, 1.0};
+const std::vector<double> kLowerY{0.0, 2.0};
+const std::vector<double> kUpperX{1.0, 2.0};
+const std::vector<double> kUpperY{10.0, 14.0};
+
+Interpolation::Piecewise<Contract>
+Discontinuous() {
+    std::vector<Contract> pieces{Contract{kLowerX, kLowerY},
+                                 Contract{kUpperX, kUpperY}};
+    return Interpolation::Piecewise<Contract>{{0.0, 1.0, 2.0},
+                                              std::move(pieces)};
+}
+
+} // namespace
+
+TEST(PiecewiseContract, ContinuityAcrossABreakpointIsNotChecked) {
+    // Construction must succeed: a jump is data, not an error. This is the
+    // clause a consumer relies on most, because enforcing continuity here
+    // would make a layered earth model unrepresentable.
+    const auto f = Discontinuous();
+
+    ASSERT_EQ(f.PieceCount(), 2u);
+    const auto [below, above] = f.Limits(1.0);
+    EXPECT_DOUBLE_EQ(below, 2.0);
+    EXPECT_DOUBLE_EQ(above, 10.0);
+    EXPECT_NE(below, above);
+}
+
+TEST(PiecewiseContract, ThePiecesTileTheDomainWithNoGaps) {
+    const auto f = Discontinuous();
+
+    EXPECT_DOUBLE_EQ(f.Lower(), f.Breakpoint(0));
+    EXPECT_DOUBLE_EQ(f.Upper(), f.Breakpoint(f.PieceCount()));
+
+    for (std::size_t k = 0; k < f.PieceCount(); ++k) {
+        SCOPED_TRACE("piece " + std::to_string(k));
+        const auto piece = f.Piece(k);
+        EXPECT_DOUBLE_EQ(piece.Lower(), f.Breakpoint(k));
+        EXPECT_DOUBLE_EQ(piece.Upper(), f.Breakpoint(k + 1));
+        // No gap: each piece begins exactly where the last one ended.
+        if (k > 0) {
+            EXPECT_DOUBLE_EQ(f.Piece(k - 1).Upper(), piece.Lower());
+        }
+    }
+}
+
+TEST(PiecewiseContract, PieceKOwnsTheHalfOpenIntervalFromTheLeft) {
+    const auto f = Discontinuous();
+
+    // Right-continuity: landing exactly on an interior breakpoint is answered
+    // by the piece starting there.
+    EXPECT_EQ(f.IndexOf(1.0), 1u);
+    EXPECT_EQ(f.IndexOf(1.0, Interpolation::Side::Right), 1u);
+    EXPECT_EQ(f.IndexOf(1.0, Interpolation::Side::Left), 0u);
+    EXPECT_DOUBLE_EQ(f(1.0), 10.0);
+
+    // The interior of a piece is unambiguous, whichever side is asked for.
+    for (const auto x : {0.25, 0.75, 1.25, 1.75}) {
+        SCOPED_TRACE("x = " + std::to_string(x));
+        EXPECT_EQ(f.IndexOf(x, Interpolation::Side::Left),
+                  f.IndexOf(x, Interpolation::Side::Right));
+        const auto [left, right] = f.Limits(x);
+        EXPECT_DOUBLE_EQ(left, right);
+    }
+
+    // The outer breakpoints have only one piece to answer from.
+    EXPECT_EQ(f.IndexOf(0.0, Interpolation::Side::Left), 0u);
+    EXPECT_EQ(f.IndexOf(2.0, Interpolation::Side::Right), 1u);
+}
+
+TEST(PiecewiseContract, LimitsReportsTheLeftValueFirst) {
+    const auto f = Discontinuous();
+
+    const auto limits = f.Limits(1.0);
+    EXPECT_DOUBLE_EQ(limits.first,
+                     f.EvaluateFrom<0>(1.0, Interpolation::Side::Left));
+    EXPECT_DOUBLE_EQ(limits.second,
+                     f.EvaluateFrom<0>(1.0, Interpolation::Side::Right));
+
+    // The ordering is load-bearing for a caller reading a jump off a
+    // boundary, so it is stated rather than left to be inferred.
+    EXPECT_LT(limits.first, limits.second);
+}
+
+TEST(PiecewiseContract, DerivativesFollowTheSameConvention) {
+    const auto f = Discontinuous();
+
+    // Slopes 2 below and 4 above, so the derivative jumps too. Evaluate is
+    // right-continuous at every order, not only at order zero.
+    const auto [belowSlope, aboveSlope] = f.Limits<1>(1.0);
+    EXPECT_DOUBLE_EQ(belowSlope, 2.0);
+    EXPECT_DOUBLE_EQ(aboveSlope, 4.0);
+    EXPECT_DOUBLE_EQ(f.Evaluate<1>(1.0), aboveSlope);
+}
+
+TEST(PiecewiseContract, OutsideTheDomainTheEndPieceContinues) {
+    const auto f = Discontinuous();
+
+    // Not clamped and not an error: the end piece is extrapolated, which is
+    // what a solver stepping slightly past the last breakpoint needs.
+    EXPECT_EQ(f.IndexOf(-1.0), 0u);
+    EXPECT_EQ(f.IndexOf(3.0), f.PieceCount() - 1);
+    EXPECT_DOUBLE_EQ(f(-1.0), -2.0);
+    EXPECT_DOUBLE_EQ(f(3.0), 18.0);
+}

--- a/tests/TestSplineSystem.cpp
+++ b/tests/TestSplineSystem.cpp
@@ -1,0 +1,418 @@
+#include <gtest/gtest.h>
+
+#include <Interpolation/Interpolation.hpp>
+#include <cmath>
+#include <complex>
+#include <random>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include "AllocationCounter.hpp"
+#include "TestUtilities.h"
+
+// The reusable spline factorisation, and the nodal evaluation path that goes
+// with it. Both exist because a caller with many ordinate sets on one grid —
+// the components of a field, an ensemble, a line of spectral coefficients —
+// should pay for the matrix once and never binary-search for a segment it
+// already knows.
+
+namespace {
+
+using Interpolation::BoundaryCondition;
+using Interpolation::CubicSpline;
+using Interpolation::CubicSplineSystem;
+using Interpolation::Side;
+using Interpolation::SolveTridiagonal;
+using Interpolation::TridiagonalFactorization;
+
+// A diagonally dominant tridiagonal system, so the pivot-free elimination is
+// legitimate and the reference solve is well conditioned.
+struct System {
+    std::vector<double> sub, diag, super;
+};
+
+System
+DominantSystem(std::size_t n, std::uint64_t seed) {
+    std::mt19937_64 engine{seed};
+    std::uniform_real_distribution<double> off{-1.0, 1.0};
+    std::uniform_real_distribution<double> extra{0.5, 1.5};
+
+    System s{std::vector<double>(n), std::vector<double>(n),
+             std::vector<double>(n)};
+    for (std::size_t i = 0; i < n; ++i) {
+        s.sub[i] = i == 0 ? 0.0 : off(engine);
+        s.super[i] = i + 1 == n ? 0.0 : off(engine);
+        s.diag[i] = std::abs(s.sub[i]) + std::abs(s.super[i]) + extra(engine);
+    }
+    return s;
+}
+
+template <typename Scalar>
+std::vector<Scalar>
+RandomVector(std::size_t n, std::uint64_t seed) {
+    std::mt19937_64 engine{seed};
+    std::uniform_real_distribution<double> value{-2.0, 2.0};
+    std::vector<Scalar> v(n);
+    for (auto &entry : v) {
+        if constexpr (Interpolation::Complex<Scalar>) {
+            entry = Scalar{value(engine), value(engine)};
+        } else {
+            entry = value(engine);
+        }
+    }
+    return v;
+}
+
+// Nodes with genuinely uneven spacing: a uniform grid hides the not-a-knot
+// pivot problem the slope formulation exists to avoid.
+const std::vector<double> kNodes{0.0, 0.4, 1.5, 1.7, 2.9, 4.4, 4.6, 6.0};
+
+std::vector<double>
+SampledOn(const std::vector<double> &x) {
+    std::vector<double> y;
+    y.reserve(x.size());
+    for (const auto value : x) {
+        y.push_back(std::exp(-0.3 * value) * std::sin(1.7 * value) +
+                    0.2 * value);
+    }
+    return y;
+}
+
+std::vector<std::complex<double>>
+ComplexSampledOn(const std::vector<double> &x) {
+    std::vector<std::complex<double>> y;
+    y.reserve(x.size());
+    for (const auto value : x) {
+        y.emplace_back(std::cos(1.1 * value), std::exp(-0.2 * value));
+    }
+    return y;
+}
+
+} // namespace
+
+// --- TridiagonalFactorization -----------------------------------------------
+
+TEST(TridiagonalFactorization, AgreesWithTheOneShotSolve) {
+    const auto seed = InterpolationTest::ReportedSeed(20260823);
+
+    for (const std::size_t n : {1u, 2u, 3u, 9u, 64u}) {
+        const auto system = DominantSystem(n, seed + n);
+        const auto rhs = RandomVector<double>(n, seed + 1000 + n);
+
+        // The one-shot solve consumes its diagonal, so it gets a copy.
+        auto diagCopy = system.diag;
+        auto reference = rhs;
+        SolveTridiagonal<double, double>(std::span<const double>{system.sub},
+                                         std::span<double>{diagCopy},
+                                         std::span<const double>{system.super},
+                                         std::span<double>{reference});
+
+        const TridiagonalFactorization<double> factorization{
+            std::span<const double>{system.sub},
+            std::span<const double>{system.diag},
+            std::span<const double>{system.super}};
+        ASSERT_EQ(factorization.Size(), n);
+
+        auto solution = rhs;
+        factorization.Solve(std::span<double>{solution});
+
+        for (std::size_t i = 0; i < n; ++i) {
+            SCOPED_TRACE("n = " + std::to_string(n) + ", row " +
+                         std::to_string(i));
+            EXPECT_NEAR(solution[i], reference[i],
+                        1.0e-12 * (1.0 + std::abs(reference[i])));
+        }
+    }
+}
+
+TEST(TridiagonalFactorization, OneFactorisationServesManyRightHandSides) {
+    const auto seed = InterpolationTest::ReportedSeed(20260823);
+    constexpr std::size_t n = 32;
+    const auto system = DominantSystem(n, seed);
+
+    const TridiagonalFactorization<double> factorization{
+        std::span<const double>{system.sub},
+        std::span<const double>{system.diag},
+        std::span<const double>{system.super}};
+
+    // The point of the class: solving repeatedly must not degrade, because
+    // nothing the factorisation holds is consumed by a solve.
+    for (int k = 0; k < 8; ++k) {
+        const auto rhs = RandomVector<double>(n, seed + 7919 * k);
+
+        auto diagCopy = system.diag;
+        auto reference = rhs;
+        SolveTridiagonal<double, double>(std::span<const double>{system.sub},
+                                         std::span<double>{diagCopy},
+                                         std::span<const double>{system.super},
+                                         std::span<double>{reference});
+
+        auto solution = rhs;
+        factorization.Solve(std::span<double>{solution});
+        for (std::size_t i = 0; i < n; ++i) {
+            SCOPED_TRACE("solve " + std::to_string(k));
+            EXPECT_NEAR(solution[i], reference[i],
+                        1.0e-12 * (1.0 + std::abs(reference[i])));
+        }
+    }
+}
+
+TEST(TridiagonalFactorization, ARealMatrixActsOnAComplexRightHandSide) {
+    const auto seed = InterpolationTest::ReportedSeed(20260823);
+    constexpr std::size_t n = 24;
+    const auto system = DominantSystem(n, seed);
+
+    const TridiagonalFactorization<double> factorization{
+        std::span<const double>{system.sub},
+        std::span<const double>{system.diag},
+        std::span<const double>{system.super}};
+
+    const auto rhs = RandomVector<std::complex<double>>(n, seed + 11);
+    auto solution = rhs;
+    factorization.Solve(std::span<std::complex<double>>{solution});
+
+    // The matrix is real, so the real and imaginary parts must solve
+    // independently. That is exactly why the class is not templated on the
+    // right-hand side type.
+    std::vector<double> realPart(n), imagPart(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        realPart[i] = rhs[i].real();
+        imagPart[i] = rhs[i].imag();
+    }
+    factorization.Solve(std::span<double>{realPart});
+    factorization.Solve(std::span<double>{imagPart});
+
+    for (std::size_t i = 0; i < n; ++i) {
+        EXPECT_NEAR(solution[i].real(), realPart[i], 1.0e-13);
+        EXPECT_NEAR(solution[i].imag(), imagPart[i], 1.0e-13);
+    }
+}
+
+TEST(TridiagonalFactorization, RejectsMalformedSystems) {
+    const std::vector<double> three{1.0, 1.0, 1.0};
+    const std::vector<double> two{1.0, 1.0};
+    const std::vector<double> none{};
+
+    EXPECT_THROW(
+        (TridiagonalFactorization<double>{std::span<const double>{none},
+                                          std::span<const double>{none},
+                                          std::span<const double>{none}}),
+        std::invalid_argument);
+
+    EXPECT_THROW(
+        (TridiagonalFactorization<double>{std::span<const double>{two},
+                                          std::span<const double>{three},
+                                          std::span<const double>{three}}),
+        std::invalid_argument);
+
+    // A zero pivot is reported where it is met, rather than left to produce
+    // infinities inside somebody's solve.
+    const std::vector<double> zeroDiag{0.0, 1.0, 1.0};
+    EXPECT_THROW(
+        (TridiagonalFactorization<double>{std::span<const double>{three},
+                                          std::span<const double>{zeroDiag},
+                                          std::span<const double>{three}}),
+        std::invalid_argument);
+
+    // Dominant, so this one factorises: the check under test is the length of
+    // the right-hand side, not the matrix.
+    const std::vector<double> dominant{4.0, 4.0, 4.0};
+    const TridiagonalFactorization<double> factorization{
+        std::span<const double>{three}, std::span<const double>{dominant},
+        std::span<const double>{three}};
+    std::vector<double> wrongLength(2);
+    EXPECT_THROW(factorization.Solve(std::span<double>{wrongLength}),
+                 std::invalid_argument);
+}
+
+// --- CubicSplineSystem ------------------------------------------------------
+
+template <typename Scalar>
+void
+CheckSystemReproducesTheSpline(const std::vector<double> &x,
+                               const std::vector<Scalar> &y,
+                               BoundaryCondition left, Scalar leftDerivative,
+                               BoundaryCondition right,
+                               Scalar rightDerivative) {
+    const CubicSpline spline{
+        x, y, left, leftDerivative, right, rightDerivative};
+    const CubicSplineSystem system{x, left, right};
+
+    std::vector<Scalar> curvature(x.size());
+    system.Solve(y, leftDerivative, rightDerivative,
+                 std::span<Scalar>{curvature});
+
+    const auto reference = spline.Curvatures();
+    ASSERT_EQ(curvature.size(), reference.size());
+    for (std::size_t i = 0; i < curvature.size(); ++i) {
+        SCOPED_TRACE("node " + std::to_string(i));
+        // Bit-for-bit: the spline is solved by this very system, so anything
+        // else would mean two assemblies had crept back in.
+        EXPECT_EQ(curvature[i], reference[i]);
+    }
+}
+
+TEST(CubicSplineSystem, ReproducesTheSplineForEveryBoundaryCondition) {
+    const auto y = SampledOn(kNodes);
+
+    CheckSystemReproducesTheSpline(kNodes, y, BoundaryCondition::Natural, 0.0,
+                                   BoundaryCondition::Natural, 0.0);
+    CheckSystemReproducesTheSpline(kNodes, y, BoundaryCondition::NotAKnot, 0.0,
+                                   BoundaryCondition::NotAKnot, 0.0);
+    CheckSystemReproducesTheSpline(kNodes, y, BoundaryCondition::Clamped, -0.7,
+                                   BoundaryCondition::Clamped, 1.3);
+    // Mixed ends: the derivative given for the Natural end is ignored.
+    CheckSystemReproducesTheSpline(kNodes, y, BoundaryCondition::Clamped, -0.7,
+                                   BoundaryCondition::Natural, 99.0);
+    CheckSystemReproducesTheSpline(kNodes, y, BoundaryCondition::Natural, 99.0,
+                                   BoundaryCondition::Clamped, 1.3);
+}
+
+TEST(CubicSplineSystem, ReproducesTheSplineForComplexOrdinates) {
+    const auto y = ComplexSampledOn(kNodes);
+    using C = std::complex<double>;
+
+    CheckSystemReproducesTheSpline(kNodes, y, BoundaryCondition::Natural, C{},
+                                   BoundaryCondition::Natural, C{});
+    CheckSystemReproducesTheSpline(kNodes, y, BoundaryCondition::NotAKnot, C{},
+                                   BoundaryCondition::NotAKnot, C{});
+    CheckSystemReproducesTheSpline(kNodes, y, BoundaryCondition::Clamped,
+                                   C{0.4, -1.1}, BoundaryCondition::Clamped,
+                                   C{-0.2, 0.9});
+}
+
+TEST(CubicSplineSystem, OneFactorisationSolvesManyOrdinateSets) {
+    const auto seed = InterpolationTest::ReportedSeed(20260823);
+    const CubicSplineSystem system{kNodes, BoundaryCondition::NotAKnot};
+
+    std::vector<double> curvature(kNodes.size());
+    for (int line = 0; line < 16; ++line) {
+        const auto y = RandomVector<double>(kNodes.size(), seed + 31 * line);
+
+        system.Solve(y, std::span<double>{curvature});
+
+        // Against a spline built from scratch on the same data, which is the
+        // implementation GSHTrans is replacing.
+        const CubicSpline spline{kNodes, y, BoundaryCondition::NotAKnot, 0.0,
+                                 0.0};
+        const auto reference = spline.Curvatures();
+        for (std::size_t i = 0; i < curvature.size(); ++i) {
+            SCOPED_TRACE("line " + std::to_string(line) + ", node " +
+                         std::to_string(i));
+            EXPECT_EQ(curvature[i], reference[i]);
+        }
+    }
+}
+
+TEST(CubicSplineSystem, SolvingAllocatesNothing) {
+    if constexpr (!InterpolationTest::AllocationCountingEnabled()) {
+        GTEST_SKIP() << "allocation counting stands down under sanitizers";
+    } else {
+        {
+            const auto before = InterpolationTest::AllocationCount();
+            void *probe = ::operator new(64);
+            ::operator delete(probe);
+            ASSERT_GT(InterpolationTest::AllocationCount(), before)
+                << "the allocation counter is not observing allocations";
+        }
+
+        // This is the claim that makes the class worth having: the matrix is
+        // built once, and a solve after that is arithmetic and nothing else.
+        for (const auto condition :
+             {BoundaryCondition::Natural, BoundaryCondition::NotAKnot}) {
+            const CubicSplineSystem system{kNodes, condition};
+            const auto y = SampledOn(kNodes);
+            std::vector<double> curvature(kNodes.size());
+            std::vector<double> nodal(kNodes.size());
+
+            const auto before = InterpolationTest::AllocationCount();
+            for (int line = 0; line < 64; ++line) {
+                system.Solve(y, std::span<double>{curvature});
+                system.EvaluateAtNodes<1>(y, curvature,
+                                          std::span<double>{nodal});
+            }
+            const auto after = InterpolationTest::AllocationCount();
+
+            EXPECT_EQ(after, before)
+                << "solving allocated " << (after - before) << " times";
+        }
+    }
+}
+
+TEST(CubicSplineSystem, CurvaturesReturnsWhatSolveWrites) {
+    const auto y = SampledOn(kNodes);
+    const CubicSplineSystem system{kNodes, BoundaryCondition::Natural};
+
+    std::vector<double> curvature(kNodes.size());
+    system.Solve(y, std::span<double>{curvature});
+    const auto returned = system.Curvatures(y);
+
+    ASSERT_EQ(returned.size(), curvature.size());
+    for (std::size_t i = 0; i < curvature.size(); ++i) {
+        EXPECT_EQ(returned[i], curvature[i]);
+    }
+}
+
+TEST(CubicSplineSystem, ReportsTheGridItWasBuiltOn) {
+    const CubicSplineSystem system{kNodes, BoundaryCondition::Clamped,
+                                   BoundaryCondition::Natural};
+    ASSERT_EQ(system.Size(), kNodes.size());
+    EXPECT_EQ(system.LeftCondition(), BoundaryCondition::Clamped);
+    EXPECT_EQ(system.RightCondition(), BoundaryCondition::Natural);
+    for (std::size_t i = 0; i < kNodes.size(); ++i) {
+        EXPECT_EQ(system.Node(i), kNodes[i]);
+    }
+    for (std::size_t i = 0; i + 1 < kNodes.size(); ++i) {
+        EXPECT_EQ(system.Spacing(i), kNodes[i + 1] - kNodes[i]);
+    }
+}
+
+TEST(CubicSplineSystem, RejectsMalformedInput) {
+    const std::vector<double> decreasing{0.0, 2.0, 1.0, 3.0};
+    EXPECT_THROW((CubicSplineSystem{decreasing}), std::invalid_argument);
+
+    const std::vector<double> tooShort{0.0};
+    EXPECT_THROW((CubicSplineSystem{tooShort}), std::invalid_argument);
+
+    // NotAKnot needs four nodes and both ends.
+    const std::vector<double> three{0.0, 1.0, 2.0};
+    EXPECT_THROW((CubicSplineSystem{three, BoundaryCondition::NotAKnot}),
+                 std::invalid_argument);
+    EXPECT_THROW((CubicSplineSystem{kNodes, BoundaryCondition::NotAKnot,
+                                    BoundaryCondition::Natural}),
+                 std::invalid_argument);
+
+    const CubicSplineSystem system{kNodes};
+    const auto y = SampledOn(kNodes);
+    std::vector<double> curvature(kNodes.size());
+    std::vector<double> wrongLength(kNodes.size() - 1);
+
+    EXPECT_THROW(system.Solve(wrongLength, std::span<double>{curvature}),
+                 std::invalid_argument);
+    EXPECT_THROW(system.Solve(y, std::span<double>{wrongLength}),
+                 std::invalid_argument);
+
+    // A Clamped end has no derivative to use unless one is handed over.
+    const CubicSplineSystem clamped{kNodes, BoundaryCondition::Clamped};
+    EXPECT_THROW(clamped.Solve(y, std::span<double>{curvature}),
+                 std::invalid_argument);
+    EXPECT_NO_THROW(clamped.Solve(y, 0.5, -0.5, std::span<double>{curvature}));
+}
+
+TEST(CubicSplineSystem, ASplineExposesItsOwnFactorisation) {
+    const auto y = SampledOn(kNodes);
+    const CubicSpline spline{kNodes, y};
+
+    // Having fitted one line, a caller who finds more data on the same grid
+    // reuses the matrix rather than assembling it again.
+    const auto other = ComplexSampledOn(kNodes);
+    const auto curvature = spline.SplineSystem().Curvatures(other);
+
+    const CubicSpline reference{kNodes, other};
+    const auto expected = reference.Curvatures();
+    ASSERT_EQ(curvature.size(), expected.size());
+    for (std::size_t i = 0; i < curvature.size(); ++i) {
+        EXPECT_EQ(curvature[i], expected[i]);
+    }
+}


### PR DESCRIPTION
A consumer took the library up, used it, and wrote docs/Interpolation-for-GSHTrans.md saying what would make it more useful. All four asks are done.

Expose the spline factorisation. A cubic spline's matrix depends on the nodes alone; only the right-hand side carries the ordinates. GSHTrans, with no way to reach that, had grown its own copy of the spline system and a Thomas sweep to go with it -- two implementations of one spline across two repositories, which costs more than the 1.2x to 2x it measured. CubicSplineSystem is now that matrix and TridiagonalFactorization the reduced form underneath it, both public. The elimination happens once at construction and keeps its pivots, which the old one-shot solver destroyed; Solve is then a forward sweep and a back substitution with no division at all, allocating nothing and const so a fixed system is shareable across threads. Not-a-knot converts its slopes to curvatures in place, so it needs no scratch either. CubicSpline is built on the system, so the spline equations are assembled in one place rather than one per caller, and BicubicSpline now builds one system per axis instead of one per line -- which is what a tensor product should have been doing all along. Detail::NaturalCurvatures and Detail::NotAKnotCurvatures go, superseded.

Add an evaluate-at-the-nodes path. EvaluateAtNodes<N> and NodeValues<N> on Linear, CubicSpline and AkimaSpline, and on CubicSplineSystem for a caller working from ordinates and curvatures directly. Evaluating at a node is the one query that needs no search, since the adjoining segment is known. The sided cases -- the third derivative of a cubic, the first of a piecewise-linear interpolant -- take the Side that Piecewise already defined, moved to its own header so one convention covers breakpoints and nodes alike. The default is right-continuous, so a nodal sweep agrees with an ordinary query bit for bit.

Add a GCC 13 leg to CI, with a matching preset. It is the compiler on the deployment target for the codes GSHTrans serves. Nothing needed fixing; the leg keeps it that way by construction rather than by inspection.

Pin Piecewise's conventions with tests. A consumer has built its own element partition to match them, so right-continuity, the ordering of Limits, gapless tiling and the deliberate absence of a continuity check are now stated in a PiecewiseContract group instead of holding by construction.

Suite goes 92 to 119, green on GCC 13, GCC 14 and Clang 18 in Release and Debug, clean under ASan and UBSan. The curvatures the new system produces are bit-for-bit what the old code produced, which is what the tests assert. At 512 lines on one grid the shared factorisation with a nodal sweep runs 2.8x to 5.0x the spline-per-line path at zero relative difference; example 11 and a benchmark case cover it.

Doxygen excludes the hand-over notes, which name members in running text that it reads as unresolvable link requests.


Claude-Session: https://claude.ai/code/session_01GNaJndKkyTSWQEVdRhutks